### PR TITLE
feat: QR-code authentication as primary login method

### DIFF
--- a/provider/__init__.py
+++ b/provider/__init__.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, cast
 
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption, ConfigValueType
 from music_assistant_models.enums import ConfigEntryType, ProviderFeature
+from music_assistant_models.errors import LoginFailed
 
 from .constants import (
     CONF_ACTION_AUTH_QR,
@@ -70,7 +71,10 @@ async def get_config_entries(
 
     # Handle QR auth action
     if action == CONF_ACTION_AUTH_QR:
-        x_token, music_token = await perform_qr_auth(mass, str(values["session_id"]))
+        session_id = values.get("session_id")
+        if not session_id:
+            raise LoginFailed("Missing session_id for QR authentication")
+        x_token, music_token = await perform_qr_auth(mass, str(session_id))
         values[CONF_TOKEN] = music_token
         if values.get(CONF_REMEMBER_SESSION, True):
             values[CONF_X_TOKEN] = x_token

--- a/provider/__init__.py
+++ b/provider/__init__.py
@@ -8,12 +8,15 @@ from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
 from music_assistant_models.enums import ConfigEntryType, ProviderFeature
 
 from .constants import (
+    CONF_ACTION_AUTH_QR,
     CONF_ACTION_CLEAR_AUTH,
     CONF_BASE_URL,
     CONF_LIKED_TRACKS_MAX_TRACKS,
     CONF_MY_WAVE_MAX_TRACKS,
     CONF_QUALITY,
+    CONF_REMEMBER_SESSION,
     CONF_TOKEN,
+    CONF_X_TOKEN,
     DEFAULT_BASE_URL,
     QUALITY_BALANCED,
     QUALITY_EFFICIENT,
@@ -21,6 +24,7 @@ from .constants import (
     QUALITY_SUPERB,
 )
 from .provider import YandexMusicProvider
+from .yandex_auth import perform_qr_auth
 
 if TYPE_CHECKING:
     from music_assistant_models.config_entries import ProviderConfig
@@ -55,7 +59,7 @@ async def setup(
 
 
 async def get_config_entries(
-    mass: MusicAssistant,  # noqa: ARG001
+    mass: MusicAssistant,
     instance_id: str | None = None,  # noqa: ARG001
     action: str | None = None,
     values: dict[str, ConfigValueType] | None = None,
@@ -64,32 +68,92 @@ async def get_config_entries(
     if values is None:
         values = {}
 
+    # Handle QR auth action
+    if action == CONF_ACTION_AUTH_QR:
+        x_token, music_token = await perform_qr_auth(mass, str(values["session_id"]))
+        values[CONF_TOKEN] = music_token
+        if values.get(CONF_REMEMBER_SESSION, True):
+            values[CONF_X_TOKEN] = x_token
+        else:
+            values[CONF_X_TOKEN] = None
+
     # Handle clear auth action
     if action == CONF_ACTION_CLEAR_AUTH:
         values[CONF_TOKEN] = None
+        values[CONF_X_TOKEN] = None
 
     # Check if user is authenticated
     is_authenticated = bool(values.get(CONF_TOKEN))
 
+    # Dynamic label text
+    if not is_authenticated:
+        label_text = (
+            "Scan a QR code with the Yandex app on your phone to authenticate.\n\n"
+            "Alternatively, you can enter a music token manually in the advanced settings."
+        )
+    elif action == CONF_ACTION_AUTH_QR:
+        label_text = "Authenticated to Yandex Music. Don't forget to save to complete setup."
+    else:
+        label_text = "Authenticated to Yandex Music."
+
     return (
-        # Authentication
+        # Status label
         ConfigEntry(
-            key=CONF_TOKEN,
-            type=ConfigEntryType.SECURE_STRING,
-            label="Yandex Music Token",
-            description="Enter your Yandex Music OAuth token. "
-            "See the documentation for how to obtain it.",
-            required=True,
-            hidden=is_authenticated,
-            value=cast("str", values.get(CONF_TOKEN)) if values else None,
+            key="label_text",
+            type=ConfigEntryType.LABEL,
+            label=label_text,
         ),
+        # QR authentication (primary)
+        ConfigEntry(
+            key=CONF_ACTION_AUTH_QR,
+            type=ConfigEntryType.ACTION,
+            label="Login with QR code",
+            description="Opens a QR code page — scan it with the Yandex app on your phone.",
+            action=CONF_ACTION_AUTH_QR,
+            action_label="Login with QR code",
+            hidden=is_authenticated,
+        ),
+        # Remember session toggle
+        ConfigEntry(
+            key=CONF_REMEMBER_SESSION,
+            type=ConfigEntryType.BOOLEAN,
+            label="Remember session (auto-refresh token)",
+            description="When enabled, stores a long-lived session token to automatically "
+            "refresh your music token when it expires. When disabled, you must "
+            "re-authenticate manually when the token expires.",
+            default_value=True,
+            hidden=is_authenticated,
+        ),
+        # Clear auth
         ConfigEntry(
             key=CONF_ACTION_CLEAR_AUTH,
             type=ConfigEntryType.ACTION,
             label="Reset authentication",
             description="Clear the current authentication details.",
             action=CONF_ACTION_CLEAR_AUTH,
+            action_label="Reset authentication",
             hidden=not is_authenticated,
+        ),
+        # Manual token entry (advanced fallback)
+        ConfigEntry(
+            key=CONF_TOKEN,
+            type=ConfigEntryType.SECURE_STRING,
+            label="Yandex Music Token (manual)",
+            description="Advanced: manually enter a music token instead of using QR login. "
+            "See the documentation for how to obtain it.",
+            required=False,
+            hidden=is_authenticated,
+            advanced=True,
+            value=cast("str", values.get(CONF_TOKEN)) if values else None,
+        ),
+        # x_token (internal storage, always hidden)
+        ConfigEntry(
+            key=CONF_X_TOKEN,
+            type=ConfigEntryType.SECURE_STRING,
+            label="Session token",
+            hidden=True,
+            required=False,
+            value=cast("str", values.get(CONF_X_TOKEN)) if values else None,
         ),
         # Quality
         ConfigEntry(

--- a/provider/api_client.py
+++ b/provider/api_client.py
@@ -772,10 +772,10 @@ class YandexMusicClient:
             )
         except Exception as err:
             LOGGER.warning(
-                "get-file-info lossless for track %s: Unexpected error: %s",
+                "get-file-info lossless for track %s: Unexpected %s: %s",
                 track_id,
+                type(err).__name__,
                 err,
-                exc_info=True,
             )
 
         return None

--- a/provider/constants.py
+++ b/provider/constants.py
@@ -11,7 +11,12 @@ CONF_BASE_URL = "base_url"
 
 # Actions
 CONF_ACTION_AUTH = "auth"
+CONF_ACTION_AUTH_QR = "auth_qr"
 CONF_ACTION_CLEAR_AUTH = "clear_auth"
+
+# QR authentication config keys
+CONF_X_TOKEN = "x_token"
+CONF_REMEMBER_SESSION = "remember_session"
 
 # Labels
 LABEL_TOKEN = "token_label"

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -189,12 +189,21 @@ class YandexMusicProvider(MusicProvider):
                 self._client = YandexMusicClient(new_music_token, base_url=str(base_url))
                 await self._client.connect()
                 self.logger.info("Refreshed music token from session token")
-            except Exception as err:
-                # Both tokens dead — clear and fail
-                self.logger.warning("Session token refresh failed: %s", type(err).__name__)
+            except LoginFailed as err:
+                # Definitive auth failure — clear dead credentials
+                self.logger.warning("Session token is invalid or expired")
                 self._update_config_value(CONF_TOKEN, None, encrypted=True)
                 self._update_config_value(CONF_X_TOKEN, None, encrypted=True)
                 raise LoginFailed("Session token expired. Please re-authenticate.") from err
+            except Exception as err:
+                # Transient/network failure — keep credentials for retry
+                self.logger.warning(
+                    "Session token refresh failed (network): %s",
+                    type(err).__name__,
+                )
+                raise ProviderUnavailableError(
+                    "Unable to refresh music token right now. Please try again later."
+                ) from err
 
         # Suppress yandex_music library DEBUG dumps (full API request/response JSON)
         logging.getLogger("yandex_music").setLevel(self.logger.level + 10)

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -47,6 +47,7 @@ from .constants import (
     CONF_LIKED_TRACKS_MAX_TRACKS,
     CONF_MY_WAVE_MAX_TRACKS,
     CONF_TOKEN,
+    CONF_X_TOKEN,
     DEFAULT_BASE_URL,
     DISCOVERY_INITIAL_TRACKS,
     FOR_YOU_FOLDER_ID,
@@ -84,6 +85,7 @@ from .parsers import (
     parse_track,
 )
 from .streaming import YandexMusicStreamingManager
+from .yandex_auth import refresh_music_token
 
 if TYPE_CHECKING:
     from music_assistant_models.streamdetails import StreamDetails
@@ -157,12 +159,43 @@ class YandexMusicProvider(MusicProvider):
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
         token = self.config.get_value(CONF_TOKEN)
-        if not token:
-            raise LoginFailed("No Yandex Music token provided")
-
+        x_token = self.config.get_value(CONF_X_TOKEN)
         base_url = self.config.get_value(CONF_BASE_URL, DEFAULT_BASE_URL)
-        self._client = YandexMusicClient(str(token), base_url=str(base_url))
-        await self._client.connect()
+
+        if not token and not x_token:
+            raise LoginFailed("No Yandex Music token provided. Please authenticate.")
+
+        # Try existing music token first (fast path)
+        if token:
+            try:
+                self._client = YandexMusicClient(str(token), base_url=str(base_url))
+                await self._client.connect()
+            except LoginFailed:
+                self.logger.warning("Music token is invalid or expired")
+                if x_token:
+                    self.logger.info("Attempting to refresh from session token")
+                    token = None
+                    self._client = None
+                else:
+                    # Clear dead token and fail
+                    self._update_config_value(CONF_TOKEN, None, encrypted=True)
+                    raise
+
+        # Refresh from x_token if music token absent or failed
+        if not token and x_token:
+            try:
+                new_music_token = await refresh_music_token(str(x_token))
+                self._update_config_value(CONF_TOKEN, new_music_token, encrypted=True)
+                self._client = YandexMusicClient(new_music_token, base_url=str(base_url))
+                await self._client.connect()
+                self.logger.info("Refreshed music token from session token")
+            except Exception as err:
+                # Both tokens dead — clear and fail
+                self.logger.warning("Session token refresh failed: %s", type(err).__name__)
+                self._update_config_value(CONF_TOKEN, None, encrypted=True)
+                self._update_config_value(CONF_X_TOKEN, None, encrypted=True)
+                raise LoginFailed("Session token expired. Please re-authenticate.") from err
+
         # Suppress yandex_music library DEBUG dumps (full API request/response JSON)
         logging.getLogger("yandex_music").setLevel(self.logger.level + 10)
         self._streaming = YandexMusicStreamingManager(self)

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -172,13 +172,13 @@ class YandexMusicProvider(MusicProvider):
                 await self._client.connect()
             except LoginFailed:
                 self.logger.warning("Music token is invalid or expired")
+                # Clear the dead token so restarts go straight to refresh
+                self._update_config_value(CONF_TOKEN, None, encrypted=True)
                 if x_token:
                     self.logger.info("Attempting to refresh from session token")
                     token = None
                     self._client = None
                 else:
-                    # Clear dead token and fail
-                    self._update_config_value(CONF_TOKEN, None, encrypted=True)
                     raise
 
         # Refresh from x_token if music token absent or failed

--- a/provider/yandex_auth.py
+++ b/provider/yandex_auth.py
@@ -70,7 +70,12 @@ class YandexQRAuth:
                     raise LoginFailed(
                         f"Unexpected response type from {resp.url.path}: {resp.content_type}"
                     )
-                return await resp.json()  # type: ignore[no-any-return]
+                try:
+                    return await resp.json()  # type: ignore[no-any-return]
+                except (ValueError, aiohttp.ContentTypeError) as err:
+                    raise LoginFailed(
+                        f"Invalid JSON response from {resp.url.path} (HTTP {resp.status})"
+                    ) from err
         except LoginFailed:
             raise
         except aiohttp.ClientError as err:
@@ -112,7 +117,10 @@ class YandexQRAuth:
         if data.get("status") != "ok":
             raise LoginFailed("Failed to create QR auth session")
 
-        track_id = str(data["track_id"])
+        track_id_value = data.get("track_id")
+        if not track_id_value:
+            raise LoginFailed("Yandex Passport response missing track_id")
+        track_id = str(track_id_value)
         csrf_token = str(data.get("csrf_token", csrf_token))
         qr_url = f"{PASSPORT_URL}/auth/magic/code/?track_id={track_id}"
 

--- a/provider/yandex_auth.py
+++ b/provider/yandex_auth.py
@@ -10,10 +10,11 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import aiohttp
 from music_assistant_models.errors import LoginFailed
+from yarl import URL
 
 from music_assistant.helpers.auth import AuthenticationHelper
 
@@ -51,6 +52,30 @@ class YandexQRAuth:
         """Initialize with a dedicated aiohttp session."""
         self._session = session
 
+    async def _post_json(
+        self,
+        url: str,
+        data: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        """POST request with HTTP status validation and JSON parsing.
+
+        Wraps aiohttp errors into LoginFailed with actionable messages.
+        """
+        try:
+            async with self._session.post(url, data=data, headers=headers) as resp:
+                if resp.status != 200:
+                    raise LoginFailed(f"Yandex returned HTTP {resp.status} for {resp.url.path}")
+                if "json" not in (resp.content_type or ""):
+                    raise LoginFailed(
+                        f"Unexpected response type from {resp.url.path}: {resp.content_type}"
+                    )
+                return await resp.json()  # type: ignore[no-any-return]
+        except LoginFailed:
+            raise
+        except aiohttp.ClientError as err:
+            raise LoginFailed(f"Network error during Yandex auth: {type(err).__name__}") from err
+
     async def get_qr(self) -> tuple[str, str, str]:
         """Start QR code auth session.
 
@@ -58,30 +83,37 @@ class YandexQRAuth:
         Raises LoginFailed on any error.
         """
         # Step 1: Get CSRF token from passport page
-        async with self._session.get(f"{PASSPORT_URL}/am?app_platform=android") as resp:
-            html = await resp.text()
-            match = re.search(r'"csrf_token"\s*value="([^"]+)"', html)
-            if not match:
-                raise LoginFailed("Failed to obtain CSRF token from Yandex Passport")
+        try:
+            async with self._session.get(f"{PASSPORT_URL}/am?app_platform=android") as resp:
+                if resp.status != 200:
+                    raise LoginFailed(f"Yandex Passport returned HTTP {resp.status}")
+                html = await resp.text()
+        except aiohttp.ClientError as err:
+            raise LoginFailed(
+                f"Network error reaching Yandex Passport: {type(err).__name__}"
+            ) from err
+
+        match = re.search(r'"csrf_token"\s*value="([^"]+)"', html)
+        if not match:
+            raise LoginFailed("Failed to obtain CSRF token from Yandex Passport")
 
         csrf_token = match[1]
 
         # Step 2: Create QR auth session
-        async with self._session.post(
+        data = await self._post_json(
             f"{PASSPORT_URL}/registration-validations/auth/password/submit",
             data={
                 "csrf_token": csrf_token,
                 "retpath": "https://passport.yandex.ru/profile",
                 "with_code": 1,
             },
-        ) as resp:
-            data = await resp.json()
+        )
 
         if data.get("status") != "ok":
             raise LoginFailed("Failed to create QR auth session")
 
-        track_id = data["track_id"]
-        csrf_token = data.get("csrf_token", csrf_token)
+        track_id = str(data["track_id"])
+        csrf_token = str(data.get("csrf_token", csrf_token))
         qr_url = f"{PASSPORT_URL}/auth/magic/code/?track_id={track_id}"
 
         _LOGGER.debug("QR auth session created, track_id=%s", track_id)
@@ -92,26 +124,25 @@ class YandexQRAuth:
 
         Returns True if approved, False if still pending.
         """
-        async with self._session.post(
+        data = await self._post_json(
             f"{PASSPORT_URL}/auth/new/magic/status/",
             data={"csrf_token": csrf_token, "track_id": track_id},
-        ) as resp:
-            data = await resp.json()
-
+        )
         return bool(data.get("status") == "ok")
 
     async def get_x_token(self) -> str:
         """Exchange session cookies for x_token.
 
         Must be called after successful QR auth (cookies are in the session jar).
+        Uses the public filter_cookies API to build the cookie header.
         """
-        cookies = "; ".join(
-            f"{c.key}={c.value}"
-            for c in self._session.cookie_jar
-            if c["domain"].endswith("yandex.ru")
-        )
+        passport_url = URL("https://passport.yandex.ru")
+        filtered = self._session.cookie_jar.filter_cookies(passport_url)
+        if not filtered:
+            raise LoginFailed("No Yandex session cookies found after QR auth")
+        cookies = "; ".join(f"{k}={v.value}" for k, v in filtered.items())
 
-        async with self._session.post(
+        data = await self._post_json(
             f"{PASSPORT_API_URL}/1/bundle/oauth/token_by_sessionid",
             data={
                 "client_id": PASSPORT_CLIENT_ID,
@@ -121,8 +152,7 @@ class YandexQRAuth:
                 "Ya-Client-Host": "passport.yandex.ru",
                 "Ya-Client-Cookie": cookies,
             },
-        ) as resp:
-            data = await resp.json()
+        )
 
         if "access_token" not in data:
             raise LoginFailed("Failed to exchange session for x_token")
@@ -134,7 +164,7 @@ class YandexQRAuth:
 
         Can be called standalone (no prior QR flow needed) for token refresh.
         """
-        async with self._session.post(
+        data = await self._post_json(
             MUSIC_TOKEN_URL,
             data={
                 "client_id": MUSIC_CLIENT_ID,
@@ -142,8 +172,7 @@ class YandexQRAuth:
                 "grant_type": "x-token",
                 "access_token": x_token,
             },
-        ) as resp:
-            data = await resp.json()
+        )
 
         if "access_token" not in data:
             raise LoginFailed("Failed to obtain music token from x_token")

--- a/provider/yandex_auth.py
+++ b/provider/yandex_auth.py
@@ -1,0 +1,199 @@
+"""Yandex Passport QR authentication flow.
+
+Adapted from AlexxIT/YandexStation (MIT license) and
+trudenboy/ma-provider-yandex-station session.py.
+Stripped to authentication-only; uses pure aiohttp.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from typing import TYPE_CHECKING
+
+import aiohttp
+from music_assistant_models.errors import LoginFailed
+
+from music_assistant.helpers.auth import AuthenticationHelper
+
+if TYPE_CHECKING:
+    from music_assistant import MusicAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+# Yandex Passport OAuth credentials (public, from Yandex Music Android app)
+PASSPORT_CLIENT_ID = "c0ebe342af7d48fbbbfcf2d2eedb8f9e"
+PASSPORT_CLIENT_SECRET = "ad0a908f0aa341a182a37ecd75bc319e"
+
+# Yandex Music OAuth credentials (from yandex-music-api)
+MUSIC_CLIENT_ID = "23cabbbdc6cd418abb4b39c32c41195d"
+MUSIC_CLIENT_SECRET = "53bc75238f0c4d08a118e51fe9203300"
+
+# Endpoints
+PASSPORT_URL = "https://passport.yandex.ru"
+PASSPORT_API_URL = "https://mobileproxy.passport.yandex.net"
+MUSIC_TOKEN_URL = "https://oauth.mobile.yandex.net/1/token"
+
+# Polling settings
+QR_POLL_INTERVAL = 2.0  # seconds between status checks
+QR_POLL_TIMEOUT = 120.0  # total seconds to wait for QR scan
+
+
+class YandexQRAuth:
+    """Yandex Passport QR authentication.
+
+    Uses a dedicated aiohttp session with its own cookie jar
+    to avoid leaking Yandex cookies into the shared MA session.
+    """
+
+    def __init__(self, session: aiohttp.ClientSession) -> None:
+        """Initialize with a dedicated aiohttp session."""
+        self._session = session
+
+    async def get_qr(self) -> tuple[str, str, str]:
+        """Start QR code auth session.
+
+        Returns (qr_url, csrf_token, track_id).
+        Raises LoginFailed on any error.
+        """
+        # Step 1: Get CSRF token from passport page
+        async with self._session.get(f"{PASSPORT_URL}/am?app_platform=android") as resp:
+            html = await resp.text()
+            match = re.search(r'"csrf_token"\s*value="([^"]+)"', html)
+            if not match:
+                raise LoginFailed("Failed to obtain CSRF token from Yandex Passport")
+
+        csrf_token = match[1]
+
+        # Step 2: Create QR auth session
+        async with self._session.post(
+            f"{PASSPORT_URL}/registration-validations/auth/password/submit",
+            data={
+                "csrf_token": csrf_token,
+                "retpath": "https://passport.yandex.ru/profile",
+                "with_code": 1,
+            },
+        ) as resp:
+            data = await resp.json()
+
+        if data.get("status") != "ok":
+            raise LoginFailed("Failed to create QR auth session")
+
+        track_id = data["track_id"]
+        csrf_token = data.get("csrf_token", csrf_token)
+        qr_url = f"{PASSPORT_URL}/auth/magic/code/?track_id={track_id}"
+
+        _LOGGER.debug("QR auth session created, track_id=%s", track_id)
+        return qr_url, csrf_token, track_id
+
+    async def check_qr_status(self, csrf_token: str, track_id: str) -> bool:
+        """Check if QR code was scanned and approved.
+
+        Returns True if approved, False if still pending.
+        """
+        async with self._session.post(
+            f"{PASSPORT_URL}/auth/new/magic/status/",
+            data={"csrf_token": csrf_token, "track_id": track_id},
+        ) as resp:
+            data = await resp.json()
+
+        return bool(data.get("status") == "ok")
+
+    async def get_x_token(self) -> str:
+        """Exchange session cookies for x_token.
+
+        Must be called after successful QR auth (cookies are in the session jar).
+        """
+        cookies = "; ".join(
+            f"{c.key}={c.value}"
+            for c in self._session.cookie_jar
+            if c["domain"].endswith("yandex.ru")
+        )
+
+        async with self._session.post(
+            f"{PASSPORT_API_URL}/1/bundle/oauth/token_by_sessionid",
+            data={
+                "client_id": PASSPORT_CLIENT_ID,
+                "client_secret": PASSPORT_CLIENT_SECRET,
+            },
+            headers={
+                "Ya-Client-Host": "passport.yandex.ru",
+                "Ya-Client-Cookie": cookies,
+            },
+        ) as resp:
+            data = await resp.json()
+
+        if "access_token" not in data:
+            raise LoginFailed("Failed to exchange session for x_token")
+
+        return str(data["access_token"])
+
+    async def get_music_token(self, x_token: str) -> str:
+        """Exchange x_token for a music-scoped OAuth token.
+
+        Can be called standalone (no prior QR flow needed) for token refresh.
+        """
+        async with self._session.post(
+            MUSIC_TOKEN_URL,
+            data={
+                "client_id": MUSIC_CLIENT_ID,
+                "client_secret": MUSIC_CLIENT_SECRET,
+                "grant_type": "x-token",
+                "access_token": x_token,
+            },
+        ) as resp:
+            data = await resp.json()
+
+        if "access_token" not in data:
+            raise LoginFailed("Failed to obtain music token from x_token")
+
+        return str(data["access_token"])
+
+
+async def perform_qr_auth(mass: MusicAssistant, session_id: str) -> tuple[str, str]:
+    """Perform full QR authentication flow.
+
+    Opens a QR code popup via MA frontend, polls for scan confirmation,
+    then exchanges for x_token and music_token.
+
+    Returns (x_token, music_token).
+    """
+    async with aiohttp.ClientSession(cookie_jar=aiohttp.CookieJar()) as session:
+        auth = YandexQRAuth(session)
+
+        # Get QR code URL
+        qr_url, csrf_token, track_id = await auth.get_qr()
+
+        # Open QR page in MA frontend popup
+        async with AuthenticationHelper(mass, session_id) as auth_helper:
+            auth_helper.send_url(qr_url)
+
+            # Poll for QR scan confirmation
+            elapsed = 0.0
+            while elapsed < QR_POLL_TIMEOUT:
+                await asyncio.sleep(QR_POLL_INTERVAL)
+                elapsed += QR_POLL_INTERVAL
+
+                if await auth.check_qr_status(csrf_token, track_id):
+                    _LOGGER.debug("QR code confirmed after %.0fs", elapsed)
+                    break
+            else:
+                raise LoginFailed("QR authentication timed out. Please try again.")
+
+        # Exchange cookies → x_token → music_token
+        x_token = await auth.get_x_token()
+        music_token = await auth.get_music_token(x_token)
+
+        _LOGGER.debug("QR auth complete, obtained both tokens")
+        return x_token, music_token
+
+
+async def refresh_music_token(x_token: str) -> str:
+    """Refresh music token from a stored x_token.
+
+    Creates a throwaway HTTP session for the single API call.
+    """
+    async with aiohttp.ClientSession() as session:
+        auth = YandexQRAuth(session)
+        return await auth.get_music_token(x_token)


### PR DESCRIPTION
## Summary

- Add QR-code authentication via Yandex Passport as the primary login method — users scan a QR code with the Yandex app instead of manually obtaining OAuth tokens
- Keep manual token entry as an advanced fallback for power users
- Add "Remember session" toggle to optionally store x_token for automatic music_token refresh on expiry
- Implement cascading token validation at startup: try music_token → refresh from x_token → clear dead credentials
- Fix potential token leak by removing `exc_info=True` from catch-all exception handler in `api_client.py`

## Files changed

| File | Change |
|------|--------|
| `provider/yandex_auth.py` | **New** — QR auth flow module (YandexQRAuth class, perform_qr_auth, refresh_music_token) |
| `provider/__init__.py` | Restructured config entries: QR button primary, manual token advanced, dynamic label, x_token storage |
| `provider/provider.py` | Token validation & auto-refresh in handle_async_init() |
| `provider/constants.py` | New constants: CONF_X_TOKEN, CONF_REMEMBER_SESSION, CONF_ACTION_AUTH_QR |
| `provider/api_client.py` | Security fix: remove exc_info=True from logging |

## Test plan

- [ ] QR auth flow: click "Login with QR code", scan with Yandex app, verify token stored and provider loads
- [ ] Token refresh: invalidate music_token, restart MA, verify auto-refresh from x_token
- [ ] Dead tokens: set both tokens to garbage, restart, verify both cleared and LoginFailed raised
- [ ] Remember session disabled: authenticate via QR with toggle off, verify only music_token stored
- [ ] Manual token fallback: skip QR, enter token in advanced settings, verify provider loads
- [ ] Logging audit: set DEBUG level, run auth flow, grep logs for token values — should find none

🤖 Generated with [Claude Code](https://claude.com/claude-code)