### PR TITLE
feat(streaming): native seek support for raw transport

### DIFF
--- a/provider/provider.py
+++ b/provider/provider.py
@@ -2350,7 +2350,7 @@ class YandexMusicProvider(MusicProvider):
         Handles both raw (direct) and encrypted (encraw) transports.
 
         :param streamdetails: Stream details with URL and optional decryption key.
-        :param seek_position: Seek position in seconds (delegated to ffmpeg).
+        :param seek_position: Seek position in seconds (handled by provider for raw transport).
         :return: Async generator yielding audio chunks.
         """
         async for chunk in self.streaming.get_audio_stream(streamdetails, seek_position):

--- a/provider/streaming.py
+++ b/provider/streaming.py
@@ -157,12 +157,13 @@ class YandexMusicStreamingManager:
             )
 
             # Always use StreamType.CUSTOM with windowed Range requests to prevent CDN drops.
-            # can_seek=False: provider always streams from position 0;
-            # allow_seek=True: ffmpeg handles seek with -ss input flag.
+            # Raw transport: can_seek=True — provider handles seek via Range byte offset.
+            # Encrypted transport: seeking disabled — AES-CTR seek not implemented.
             data: dict[str, Any] = {
                 "url": url,
                 "codec": codec,
                 "transport": transport,
+                "bit_rate": bit_rate,
                 # Stored for URL refresh on 4xx:
                 "fi_quality": fi_params["quality"],
                 "fi_codecs": codecs,
@@ -177,8 +178,8 @@ class YandexMusicStreamingManager:
                 stream_type=StreamType.CUSTOM,
                 duration=track.duration,
                 data=data,
-                can_seek=False,
-                allow_seek=True,
+                can_seek=not needs_decryption,
+                allow_seek=not needs_decryption,
             )
 
         # Fallback: /tracks/{id}/download-info (defensive, should rarely trigger)
@@ -696,6 +697,28 @@ class YandexMusicStreamingManager:
             raise MediaNotFoundError(f"Unsupported AES key length: {len(key_bytes)} bytes")
         return True, key_bytes
 
+    def _calculate_seek_offset(self, data: dict, seek_position: int, is_encrypted: bool) -> int:
+        """Calculate initial byte offset for raw transport seeking.
+
+        :param data: Stream data dict (must contain 'bit_rate' in kbps).
+        :param seek_position: Seek offset in seconds.
+        :param is_encrypted: Whether the stream uses AES encryption.
+        :return: Byte offset to start streaming from (0 if not applicable).
+        """
+        if not seek_position or is_encrypted:
+            return 0
+        bit_rate = data.get("bit_rate") or 0
+        if not bit_rate:
+            return 0
+        byte_offset = int(seek_position * bit_rate * 1000 / 8)
+        self.logger.debug(
+            "Seeking to %ds: byte offset %d (bitrate %d kbps)",
+            seek_position,
+            byte_offset,
+            bit_rate,
+        )
+        return byte_offset
+
     async def get_audio_stream(
         self, streamdetails: StreamDetails, seek_position: int = 0
     ) -> AsyncGenerator[bytes, None]:
@@ -711,14 +734,15 @@ class YandexMusicStreamingManager:
         Retry counter resets after each successful window.
 
         :param streamdetails: Stream details with URL (and optional decryption key).
-        :param seek_position: Always 0 (seeking delegated to ffmpeg via allow_seek=True).
+        :param seek_position: Seek offset in seconds for raw transport (0 = from start).
         :return: Async generator yielding audio bytes.
         """
         data = streamdetails.data
         is_encrypted, key_bytes = self._validate_encryption_key(data)
+        initial_byte_offset = self._calculate_seek_offset(data, seek_position, is_encrypted)
 
         max_retries = 6
-        bytes_yielded = 0
+        bytes_yielded = initial_byte_offset
         attempt = 0
         retry_delay: float = 0.0
 

--- a/provider/streaming.py
+++ b/provider/streaming.py
@@ -697,7 +697,9 @@ class YandexMusicStreamingManager:
             raise MediaNotFoundError(f"Unsupported AES key length: {len(key_bytes)} bytes")
         return True, key_bytes
 
-    def _calculate_seek_offset(self, data: dict, seek_position: int, is_encrypted: bool) -> int:
+    def _calculate_seek_offset(
+        self, data: dict[str, Any], seek_position: int, is_encrypted: bool
+    ) -> int:
         """Calculate initial byte offset for raw transport seeking.
 
         :param data: Stream data dict (must contain 'bit_rate' in kbps).
@@ -705,12 +707,12 @@ class YandexMusicStreamingManager:
         :param is_encrypted: Whether the stream uses AES encryption.
         :return: Byte offset to start streaming from (0 if not applicable).
         """
-        if not seek_position or is_encrypted:
+        if seek_position <= 0 or is_encrypted:
             return 0
         bit_rate = data.get("bit_rate") or 0
         if not bit_rate:
             return 0
-        byte_offset = int(seek_position * bit_rate * 1000 / 8)
+        byte_offset = seek_position * bit_rate * 1000 // 8
         self.logger.debug(
             "Seeking to %ds: byte offset %d (bitrate %d kbps)",
             seek_position,

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -846,6 +846,7 @@ async def test_get_audio_stream_continues_after_non_block_boundary_drop(
 def _make_raw_stream_details(
     url: str = "https://cdn.example.com/track.flac",
     codec: str = "flac-mp4",
+    bit_rate: int = 0,
 ) -> StreamDetails:
     """Build StreamDetails for raw (unencrypted) windowed stream tests."""
     return StreamDetails(
@@ -857,6 +858,7 @@ def _make_raw_stream_details(
             "url": url,
             "codec": codec,
             "transport": "raw",
+            "bit_rate": bit_rate,
             "fi_quality": "lossless",
             "fi_codecs": "flac-mp4,flac,aac-mp4,aac,he-aac,mp3,he-aac-mp4",
         },
@@ -994,3 +996,73 @@ async def test_get_audio_stream_raw_resets_on_range_ignored(
 
     # Should get the full plaintext without duplication
     assert result == plaintext
+
+
+async def test_get_audio_stream_raw_seek_starts_from_byte_offset(
+    streaming_manager: YandexMusicStreamingManager,
+    streaming_provider_stub: StreamingProviderStub,
+) -> None:
+    """Raw stream with seek_position starts Range requests from calculated byte offset."""
+    # 320 kbps = 40000 bytes/sec; seek to 10s → offset 400000
+    bit_rate = 320
+    seek_seconds = 10
+    expected_offset = int(seek_seconds * bit_rate * 1000 / 8)  # 400000
+
+    plaintext = b"S" * 64
+    resp = _MockResponse([plaintext], status=206)
+    session = _MultiCallHttpSession([resp])
+    streaming_provider_stub.mass.http_session = session
+
+    sd = _make_raw_stream_details(bit_rate=bit_rate)
+    result = b""
+    async for chunk in streaming_manager.get_audio_stream(sd, seek_position=seek_seconds):
+        result += chunk
+
+    assert result == plaintext
+    assert len(session.calls) == 1
+    range_header = session.calls[0]["headers"]["Range"]
+    assert range_header.startswith(f"bytes={expected_offset}-")
+
+
+async def test_get_audio_stream_raw_seek_zero_bitrate_starts_from_zero(
+    streaming_manager: YandexMusicStreamingManager,
+    streaming_provider_stub: StreamingProviderStub,
+) -> None:
+    """When bit_rate is 0, seek_position is ignored and stream starts from byte 0."""
+    plaintext = b"Z" * 64
+    resp = _MockResponse([plaintext])
+    session = _MultiCallHttpSession([resp])
+    streaming_provider_stub.mass.http_session = session
+
+    sd = _make_raw_stream_details(bit_rate=0)
+    result = b""
+    async for chunk in streaming_manager.get_audio_stream(sd, seek_position=30):
+        result += chunk
+
+    assert result == plaintext
+    assert session.calls[0]["headers"]["Range"].startswith("bytes=0-")
+
+
+async def test_get_audio_stream_encrypted_ignores_seek_position(
+    streaming_manager: YandexMusicStreamingManager,
+    streaming_provider_stub: StreamingProviderStub,
+) -> None:
+    """Encrypted stream always starts from byte 0 regardless of seek_position."""
+    key = b"\x01" * 16
+    key_hex = key.hex()
+    plaintext = b"E" * 64
+    cipher = Cipher(algorithms.AES(key), modes.CTR(b"\x00" * 16))
+    encryptor = cipher.encryptor()
+    ciphertext = encryptor.update(plaintext) + encryptor.finalize()
+
+    resp = _MockResponse([ciphertext])
+    session = _MultiCallHttpSession([resp])
+    streaming_provider_stub.mass.http_session = session
+
+    sd = _make_encrypted_stream_details(key_hex)
+    result = b""
+    async for chunk in streaming_manager.get_audio_stream(sd, seek_position=30):
+        result += chunk
+
+    assert result == plaintext
+    assert session.calls[0]["headers"]["Range"].startswith("bytes=0-")


### PR DESCRIPTION
## Проблема

При `StreamType.CUSTOM` с `can_seek=False` + `allow_seek=True` MA core передаёт `seek_position=0` провайдеру и ставит ffmpeg `-ss` на stdin — ffmpeg вынужден читать и отбрасывать весь поток до точки перемотки. Это приводит к огромному расходу трафика, CPU и задержкам при seek.

Подробнее: https://github.com/music-assistant/server/pull/3606#discussion_r3084353687

## Решение

**Raw transport (без шифрования):** включаем нативный seek (`can_seek=True`, `allow_seek=True`). При seek провайдер вычисляет byte offset из `seek_position` и `bit_rate`, и начинает Range-запросы с нужной позиции.

**Encraw transport (AES-шифрование):** seek полностью отключен (`can_seek=False`, `allow_seek=False`). Encraw не является целевым транспортом и оставлен как fallback.

## Изменения

- `streaming.py`: `can_seek`/`allow_seek` условно по `needs_decryption`; `bit_rate` в `StreamDetails.data`; новый метод `_calculate_seek_offset`
- `provider.py`: обновлён docstring `get_audio_stream`
- `test_streaming.py`: 3 новых теста (seek с offset, fallback при bit_rate=0, encrypted игнорирует seek)

Все 42 теста проходят, линтер чист.