### PR TITLE
fix(device-auth): show user code in MA-served intermediate page

### DIFF
--- a/provider/device_auth.py
+++ b/provider/device_auth.py
@@ -98,11 +98,32 @@ def _build_device_code_page(user_code: str, verification_url: str) -> str:
         <a class="btn" href="{safe_url}" target="_blank" rel="noopener">Continue to Yandex</a>
     </div>
     <script>
-        document.getElementById('copy').addEventListener('click', function() {{
-            const code = document.getElementById('code').textContent.trim();
-            navigator.clipboard.writeText(code).then(() => {{
+        const copyButton = document.getElementById('copy');
+        const codeElement = document.getElementById('code');
+
+        function selectCodeForManualCopy() {{
+            if (!codeElement) return;
+            const selection = window.getSelection();
+            const range = document.createRange();
+            range.selectNodeContents(codeElement);
+            selection.removeAllRanges();
+            selection.addRange(range);
+            if (copyButton) copyButton.textContent = 'Press Ctrl/Cmd+C';
+        }}
+
+        copyButton?.addEventListener('click', async function() {{
+            const code = codeElement?.textContent?.trim();
+            if (!code) return;
+            if (!navigator.clipboard?.writeText) {{
+                selectCodeForManualCopy();
+                return;
+            }}
+            try {{
+                await navigator.clipboard.writeText(code);
                 this.textContent = 'Copied';
-            }});
+            }} catch {{
+                selectCodeForManualCopy();
+            }}
         }});
     </script>
 </body>
@@ -135,7 +156,16 @@ async def perform_device_auth(mass: MusicAssistant, session_id: str) -> tuple[st
             page_html = _build_device_code_page(session.user_code, session.verification_url)
 
             async def _serve_page(_request: web.Request) -> web.Response:
-                return web.Response(text=page_html, content_type="text/html", charset="utf-8")
+                return web.Response(
+                    text=page_html,
+                    content_type="text/html",
+                    charset="utf-8",
+                    headers={
+                        "Cache-Control": "no-store",
+                        "Pragma": "no-cache",
+                        "Expires": "0",
+                    },
+                )
 
             mass.webserver.register_dynamic_route(page_path, _serve_page, "GET")
             try:

--- a/provider/device_auth.py
+++ b/provider/device_auth.py
@@ -135,7 +135,7 @@ async def perform_device_auth(mass: MusicAssistant, session_id: str) -> tuple[st
             page_html = _build_device_code_page(session.user_code, session.verification_url)
 
             async def _serve_page(_request: web.Request) -> web.Response:
-                return web.Response(body=page_html, content_type="text/html", charset="utf-8")
+                return web.Response(text=page_html, content_type="text/html", charset="utf-8")
 
             mass.webserver.register_dynamic_route(page_path, _serve_page, "GET")
             try:

--- a/provider/device_auth.py
+++ b/provider/device_auth.py
@@ -9,9 +9,11 @@ which uses the same Passport Android ``client_id`` as the QR flow.
 
 from __future__ import annotations
 
+import html
 import logging
 from typing import TYPE_CHECKING
 
+from aiohttp import web
 from music_assistant_models.errors import LoginFailed
 from ya_passport_auth import PassportClient
 from ya_passport_auth.exceptions import DeviceCodeTimeoutError, YaPassportError
@@ -23,13 +25,97 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+_DEVICE_CODE_PAGE_PATH = "/yandex_music/device_code"
+
+
+def _build_device_code_page(user_code: str, verification_url: str) -> str:
+    """Render the HTML page shown to the user during Device Flow login.
+
+    Yandex's verification page does not pre-fill the code from query params,
+    and the MA frontend opens auth URLs in a popup that hides the address bar.
+    Serving an intermediate page lets us display the code prominently and give
+    the user an explicit "continue" action.
+    """
+    safe_code = html.escape(user_code)
+    safe_url = html.escape(verification_url, quote=True)
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Yandex Music — Device Code</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        :root {{ color-scheme: light dark; }}
+        body {{
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            margin: 0; padding: 2rem 1rem;
+            display: flex; align-items: center; justify-content: center;
+            min-height: 100vh; box-sizing: border-box;
+            background: #f5f5f7; color: #1d1d1f;
+        }}
+        @media (prefers-color-scheme: dark) {{
+            body {{ background: #1d1d1f; color: #f5f5f7; }}
+            .card {{ background: #2c2c2e; }}
+            #code {{ background: #3a3a3c; color: #fff; }}
+        }}
+        .card {{
+            background: #fff; border-radius: 14px; padding: 2rem;
+            max-width: 28rem; width: 100%;
+            box-shadow: 0 4px 20px rgba(0,0,0,.08);
+            text-align: center;
+        }}
+        h1 {{ margin: 0 0 .5rem; font-size: 1.25rem; }}
+        p {{ margin: .5rem 0 1.25rem; opacity: .75; line-height: 1.45; }}
+        #code {{
+            display: inline-block; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+            font-size: 2rem; font-weight: 600; letter-spacing: .15em;
+            padding: .75rem 1.25rem; border-radius: 10px;
+            background: #f2f2f7; user-select: all;
+        }}
+        button, .btn {{
+            display: inline-block; margin-top: 1.5rem; padding: .75rem 1.5rem;
+            font-size: 1rem; font-weight: 600; text-decoration: none;
+            border: none; border-radius: 10px; cursor: pointer;
+            background: #ffcc00; color: #1d1d1f;
+        }}
+        button:hover, .btn:hover {{ background: #ffd633; }}
+        #copy {{
+            margin-top: .75rem; background: transparent; color: inherit;
+            border: 1px solid currentColor; opacity: .7; padding: .4rem 1rem;
+            font-size: .85rem; font-weight: 400;
+        }}
+        #copy:hover {{ background: rgba(127,127,127,.1); opacity: 1; }}
+    </style>
+</head>
+<body>
+    <div class="card">
+        <h1>Login to Yandex Music</h1>
+        <p>Open the link below and enter this code to authorize Music Assistant.</p>
+        <div id="code">{safe_code}</div>
+        <div>
+            <button id="copy" type="button">Copy code</button>
+        </div>
+        <a class="btn" href="{safe_url}" target="_blank" rel="noopener">Continue to Yandex</a>
+    </div>
+    <script>
+        document.getElementById('copy').addEventListener('click', function() {{
+            const code = document.getElementById('code').textContent.trim();
+            navigator.clipboard.writeText(code).then(() => {{
+                this.textContent = 'Copied';
+            }});
+        }});
+    </script>
+</body>
+</html>
+"""
+
 
 async def perform_device_auth(mass: MusicAssistant, session_id: str) -> tuple[str, str, str]:
     """Perform Yandex OAuth Device Flow and return credential tokens.
 
-    Asks Yandex for a device code, presents the verification URL and user
-    code in the MA frontend, then polls until the user confirms or the code
-    expires.
+    Asks Yandex for a device code, presents it to the user via an intermediate
+    HTML page served from MA's own webserver, then polls until the user
+    confirms or the code expires.
 
     Returns (x_token, music_token, refresh_token) as plain strings for MA
     config storage.
@@ -38,10 +124,6 @@ async def perform_device_auth(mass: MusicAssistant, session_id: str) -> tuple[st
         async with PassportClient.create() as client:
             session = await client.start_device_login()
 
-            # AuthenticationHelper can only open one URL — append the user
-            # code as a query param so the verification page can pre-fill
-            # it (and so the user can read it from the address bar).
-            url = f"{session.verification_url}?user_code={session.user_code}"
             _LOGGER.info(
                 "Device flow started: open %s and enter code %s (expires in %ss)",
                 session.verification_url,
@@ -49,9 +131,19 @@ async def perform_device_auth(mass: MusicAssistant, session_id: str) -> tuple[st
                 session.expires_in,
             )
 
-            async with AuthenticationHelper(mass, session_id) as auth_helper:
-                auth_helper.send_url(url)
-                creds = await client.poll_device_until_confirmed(session)
+            page_path = f"{_DEVICE_CODE_PAGE_PATH}/{session_id}"
+            page_html = _build_device_code_page(session.user_code, session.verification_url)
+
+            async def _serve_page(_request: web.Request) -> web.Response:
+                return web.Response(body=page_html, content_type="text/html", charset="utf-8")
+
+            mass.webserver.register_dynamic_route(page_path, _serve_page, "GET")
+            try:
+                async with AuthenticationHelper(mass, session_id) as auth_helper:
+                    auth_helper.send_url(f"{mass.webserver.base_url}{page_path}")
+                    creds = await client.poll_device_until_confirmed(session)
+            finally:
+                mass.webserver.unregister_dynamic_route(page_path, "GET")
 
             music_token = creds.music_token
             if music_token is None:

--- a/tests/test_device_auth.py
+++ b/tests/test_device_auth.py
@@ -60,6 +60,7 @@ async def test_perform_device_auth_returns_three_tokens() -> None:
     mock_client.poll_device_until_confirmed.return_value = creds
 
     mock_mass = mock.MagicMock()
+    mock_mass.webserver.base_url = "http://ma.local:8095"
     mock_auth_helper = mock.AsyncMock()
 
     with (
@@ -83,8 +84,8 @@ async def test_perform_device_auth_returns_three_tokens() -> None:
     mock_client.poll_device_until_confirmed.assert_awaited_once_with(session)
 
 
-async def test_perform_device_auth_sends_verification_url_with_code() -> None:
-    """The verification URL is sent with user_code embedded as query param."""
+async def test_perform_device_auth_serves_intermediate_page_and_cleans_up() -> None:
+    """A temporary HTML page is registered on MA's webserver and unregistered after."""
     session = _make_device_session(
         user_code="WXYZ-9999",
         verification_url="https://oauth.yandex.ru/device",
@@ -95,6 +96,7 @@ async def test_perform_device_auth_sends_verification_url_with_code() -> None:
     mock_client.poll_device_until_confirmed.return_value = creds
 
     mock_mass = mock.MagicMock()
+    mock_mass.webserver.base_url = "http://ma.local:8095"
     mock_auth_helper = mock.AsyncMock()
 
     with (
@@ -111,19 +113,63 @@ async def test_perform_device_auth_sends_verification_url_with_code() -> None:
 
         await perform_device_auth(mock_mass, "session_1")
 
+    expected_path = "/yandex_music/device_code/session_1"
+    mock_mass.webserver.register_dynamic_route.assert_called_once()
+    register_args = mock_mass.webserver.register_dynamic_route.call_args
+    assert register_args.args[0] == expected_path
+    assert register_args.args[2] == "GET"
+    mock_mass.webserver.unregister_dynamic_route.assert_called_once_with(expected_path, "GET")
     mock_auth_helper.__aenter__.return_value.send_url.assert_called_once_with(
-        "https://oauth.yandex.ru/device?user_code=WXYZ-9999"
+        f"http://ma.local:8095{expected_path}"
     )
 
 
+async def test_perform_device_auth_route_handler_renders_code_and_url() -> None:
+    """The registered route handler returns HTML containing the code + verification URL."""
+    session = _make_device_session(
+        user_code="ABCD-1234",
+        verification_url="https://oauth.yandex.ru/device",
+    )
+    creds = _make_credentials()
+    mock_client = mock.AsyncMock()
+    mock_client.start_device_login.return_value = session
+    mock_client.poll_device_until_confirmed.return_value = creds
+
+    mock_mass = mock.MagicMock()
+    mock_mass.webserver.base_url = "http://ma.local:8095"
+    mock_auth_helper = mock.AsyncMock()
+
+    with (
+        mock.patch(
+            "music_assistant.providers.yandex_music.device_auth.PassportClient.create",
+        ) as mock_create,
+        mock.patch(
+            "music_assistant.providers.yandex_music.device_auth.AuthenticationHelper",
+            return_value=mock_auth_helper,
+        ),
+    ):
+        mock_create.return_value.__aenter__ = mock.AsyncMock(return_value=mock_client)
+        mock_create.return_value.__aexit__ = mock.AsyncMock(return_value=False)
+
+        await perform_device_auth(mock_mass, "session_1")
+
+    handler = mock_mass.webserver.register_dynamic_route.call_args.args[1]
+    response = await handler(mock.MagicMock())
+    body = response.body.decode("utf-8") if isinstance(response.body, bytes) else response.body
+    assert "ABCD-1234" in body
+    assert "https://oauth.yandex.ru/device" in body
+    assert response.content_type == "text/html"
+
+
 async def test_perform_device_auth_timeout_raises_login_failed() -> None:
-    """DeviceCodeTimeoutError from library is mapped to LoginFailed."""
+    """DeviceCodeTimeoutError from library is mapped to LoginFailed and the route is freed."""
     session = _make_device_session()
     mock_client = mock.AsyncMock()
     mock_client.start_device_login.return_value = session
     mock_client.poll_device_until_confirmed.side_effect = DeviceCodeTimeoutError("expired")
 
     mock_mass = mock.MagicMock()
+    mock_mass.webserver.base_url = "http://ma.local:8095"
     mock_auth_helper = mock.AsyncMock()
 
     with (
@@ -140,6 +186,10 @@ async def test_perform_device_auth_timeout_raises_login_failed() -> None:
 
         with pytest.raises(LoginFailed, match="timed out"):
             await perform_device_auth(mock_mass, "session_1")
+
+    mock_mass.webserver.unregister_dynamic_route.assert_called_once_with(
+        "/yandex_music/device_code/session_1", "GET"
+    )
 
 
 async def test_perform_device_auth_ya_passport_error_raises_login_failed() -> None:

--- a/tests/test_device_auth.py
+++ b/tests/test_device_auth.py
@@ -155,7 +155,8 @@ async def test_perform_device_auth_route_handler_renders_code_and_url() -> None:
 
     handler = mock_mass.webserver.register_dynamic_route.call_args.args[1]
     response = await handler(mock.MagicMock())
-    body = response.body.decode("utf-8") if isinstance(response.body, bytes) else response.body
+    body = response.text
+    assert body is not None
     assert "ABCD-1234" in body
     assert "https://oauth.yandex.ru/device" in body
     assert response.content_type == "text/html"


### PR DESCRIPTION
## Summary
- The frontend popup opened by `AuthenticationHelper.send_url` hides the address bar in many browsers, and Yandex's verification page doesn't pre-fill the code from `?user_code=` — so users had no visible way to see the code they were supposed to type.
- Register a small HTML page on `mass.webserver` for the lifetime of the device flow that displays the code prominently with a "Continue to Yandex" button, and send the user to that page first.
- Route is registered before the auth helper opens and unregistered in `finally`, so it goes away on success, timeout, or error.

## Test plan
- [x] `ruff check provider tests` — clean
- [x] `ruff format --check provider tests` — clean
- [x] Updated `tests/test_device_auth.py`:
  - `test_perform_device_auth_serves_intermediate_page_and_cleans_up` asserts route is registered with the expected path/method, sent URL is `{base_url}{path}`, and the route is unregistered after.
  - `test_perform_device_auth_route_handler_renders_code_and_url` invokes the registered handler and checks the body contains the code + verification URL.
  - `test_perform_device_auth_timeout_raises_login_failed` extended to verify the route is freed on timeout.
- [ ] Manual smoke: trigger Device Flow login in MA — popup now shows the code + a "Continue to Yandex" button instead of Yandex's blank code-entry page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)