### PR TITLE
fix(device-auth): readable popup + auto-close after authorization

### DIFF
--- a/provider/device_auth.py
+++ b/provider/device_auth.py
@@ -9,7 +9,9 @@ which uses the same Passport Android ``client_id`` as the QR flow.
 
 from __future__ import annotations
 
+import asyncio
 import html
+import json
 import logging
 from typing import TYPE_CHECKING
 
@@ -26,18 +28,27 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 _DEVICE_CODE_PAGE_PATH = "/yandex_music/device_code"
+# Seconds to keep the status endpoint alive after the flow finishes so the
+# intermediate page has a chance to poll once more and close itself.
+_POST_AUTH_GRACE_SECONDS = 3
 
 
-def _build_device_code_page(user_code: str, verification_url: str) -> str:
+def _build_device_code_page(
+    user_code: str,
+    verification_url: str,
+    status_url: str,
+) -> str:
     """Render the HTML page shown to the user during Device Flow login.
 
     Yandex's verification page does not pre-fill the code from query params,
-    and the MA frontend opens auth URLs in a popup that hides the address bar.
-    Serving an intermediate page lets us display the code prominently and give
-    the user an explicit "continue" action.
+    and the MA frontend opens auth URLs in a new tab, so the user would
+    otherwise have no signal that authorization succeeded. The page polls the
+    status endpoint and closes itself (or shows a success message) when the
+    backend signals completion.
     """
     safe_code = html.escape(user_code)
     safe_url = html.escape(verification_url, quote=True)
+    safe_status_url = json.dumps(status_url)
     return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -45,7 +56,7 @@ def _build_device_code_page(user_code: str, verification_url: str) -> str:
     <title>Yandex Music — Device Code</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
-        :root {{ color-scheme: light dark; }}
+        :root {{ color-scheme: light; }}
         body {{
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
             margin: 0; padding: 2rem 1rem;
@@ -53,24 +64,22 @@ def _build_device_code_page(user_code: str, verification_url: str) -> str:
             min-height: 100vh; box-sizing: border-box;
             background: #f5f5f7; color: #1d1d1f;
         }}
-        @media (prefers-color-scheme: dark) {{
-            body {{ background: #1d1d1f; color: #f5f5f7; }}
-            .card {{ background: #2c2c2e; }}
-            #code {{ background: #3a3a3c; color: #fff; }}
-        }}
         .card {{
-            background: #fff; border-radius: 14px; padding: 2rem;
+            background: #ffffff; color: #1d1d1f;
+            border-radius: 14px; padding: 2rem;
             max-width: 28rem; width: 100%;
             box-shadow: 0 4px 20px rgba(0,0,0,.08);
             text-align: center;
         }}
-        h1 {{ margin: 0 0 .5rem; font-size: 1.25rem; }}
-        p {{ margin: .5rem 0 1.25rem; opacity: .75; line-height: 1.45; }}
+        h1 {{ margin: 0 0 .5rem; font-size: 1.25rem; color: #1d1d1f; }}
+        p {{ margin: .5rem 0 1.25rem; color: #4a4a52; line-height: 1.45; }}
         #code {{
-            display: inline-block; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+            display: inline-block;
+            font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
             font-size: 2rem; font-weight: 600; letter-spacing: .15em;
             padding: .75rem 1.25rem; border-radius: 10px;
-            background: #f2f2f7; user-select: all;
+            background: #f2f2f7; color: #1d1d1f;
+            user-select: all;
         }}
         button, .btn {{
             display: inline-block; margin-top: 1.5rem; padding: .75rem 1.5rem;
@@ -80,15 +89,15 @@ def _build_device_code_page(user_code: str, verification_url: str) -> str:
         }}
         button:hover, .btn:hover {{ background: #ffd633; }}
         #copy {{
-            margin-top: .75rem; background: transparent; color: inherit;
-            border: 1px solid currentColor; opacity: .7; padding: .4rem 1rem;
+            margin-top: .75rem; background: transparent; color: #1d1d1f;
+            border: 1px solid #c8c8cd; padding: .4rem 1rem;
             font-size: .85rem; font-weight: 400;
         }}
-        #copy:hover {{ background: rgba(127,127,127,.1); opacity: 1; }}
+        #copy:hover {{ background: #f2f2f7; }}
     </style>
 </head>
 <body>
-    <div class="card">
+    <div class="card" id="card">
         <h1>Login to Yandex Music</h1>
         <p>Open the link below and enter this code to authorize Music Assistant.</p>
         <div id="code">{safe_code}</div>
@@ -100,6 +109,8 @@ def _build_device_code_page(user_code: str, verification_url: str) -> str:
     <script>
         const copyButton = document.getElementById('copy');
         const codeElement = document.getElementById('code');
+        const card = document.getElementById('card');
+        const statusUrl = {safe_status_url};
 
         function selectCodeForManualCopy() {{
             if (!codeElement) return;
@@ -125,6 +136,37 @@ def _build_device_code_page(user_code: str, verification_url: str) -> str:
                 selectCodeForManualCopy();
             }}
         }});
+
+        function showResult(title, message) {{
+            card.innerHTML =
+                '<h1>' + title + '</h1><p>' + message + '</p>';
+        }}
+
+        async function pollStatus() {{
+            try {{
+                const r = await fetch(statusUrl, {{ cache: 'no-store' }});
+                if (r.ok) {{
+                    const data = await r.json();
+                    if (data.state === 'done') {{
+                        showResult(
+                            'Authorization successful',
+                            'You can close this window.'
+                        );
+                        setTimeout(() => {{ try {{ window.close(); }} catch (e) {{}} }}, 300);
+                        return;
+                    }}
+                    if (data.state === 'failed') {{
+                        showResult(
+                            'Authorization failed',
+                            'Please return to Music Assistant and try again.'
+                        );
+                        return;
+                    }}
+                }}
+            }} catch (e) {{ /* network hiccup — retry */ }}
+            setTimeout(pollStatus, 2000);
+        }}
+        setTimeout(pollStatus, 2000);
     </script>
 </body>
 </html>
@@ -153,7 +195,13 @@ async def perform_device_auth(mass: MusicAssistant, session_id: str) -> tuple[st
             )
 
             page_path = f"{_DEVICE_CODE_PAGE_PATH}/{session_id}"
-            page_html = _build_device_code_page(session.user_code, session.verification_url)
+            status_path = f"{page_path}/status"
+            status_url = f"{mass.webserver.base_url}{status_path}"
+            state = {"value": "pending"}
+
+            page_html = _build_device_code_page(
+                session.user_code, session.verification_url, status_url
+            )
 
             async def _serve_page(_request: web.Request) -> web.Response:
                 return web.Response(
@@ -167,13 +215,29 @@ async def perform_device_auth(mass: MusicAssistant, session_id: str) -> tuple[st
                     },
                 )
 
+            async def _serve_status(_request: web.Request) -> web.Response:
+                return web.json_response(
+                    {"state": state["value"]},
+                    headers={"Cache-Control": "no-store"},
+                )
+
             mass.webserver.register_dynamic_route(page_path, _serve_page, "GET")
+            mass.webserver.register_dynamic_route(status_path, _serve_status, "GET")
             try:
                 async with AuthenticationHelper(mass, session_id) as auth_helper:
                     auth_helper.send_url(f"{mass.webserver.base_url}{page_path}")
-                    creds = await client.poll_device_until_confirmed(session)
+                    try:
+                        creds = await client.poll_device_until_confirmed(session)
+                    except BaseException:
+                        state["value"] = "failed"
+                        raise
+                    state["value"] = "done"
+                    # Give the intermediate page one more poll to pick up "done"
+                    # and close itself before we tear the status route down.
+                    await asyncio.sleep(_POST_AUTH_GRACE_SECONDS)
             finally:
                 mass.webserver.unregister_dynamic_route(page_path, "GET")
+                mass.webserver.unregister_dynamic_route(status_path, "GET")
 
             music_token = creds.music_token
             if music_token is None:

--- a/provider/device_auth.py
+++ b/provider/device_auth.py
@@ -48,7 +48,9 @@ def _build_device_code_page(
     """
     safe_code = html.escape(user_code)
     safe_url = html.escape(verification_url, quote=True)
-    safe_status_url = json.dumps(status_url)
+    # json.dumps emits a JS string literal, but `</script>` would still break
+    # out of the surrounding <script> block. Escape the slash to be safe.
+    safe_status_url = json.dumps(status_url).replace("</", "<\\/")
     return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -228,8 +230,14 @@ async def perform_device_auth(mass: MusicAssistant, session_id: str) -> tuple[st
                     auth_helper.send_url(f"{mass.webserver.base_url}{page_path}")
                     try:
                         creds = await client.poll_device_until_confirmed(session)
-                    except BaseException:
+                    except asyncio.CancelledError:
+                        # Don't mark cancellations as auth failures.
+                        raise
+                    except Exception:
                         state["value"] = "failed"
+                        # Give the page one more poll to surface the failure
+                        # message before we tear the status route down.
+                        await asyncio.sleep(_POST_AUTH_GRACE_SECONDS)
                         raise
                     state["value"] = "done"
                     # Give the intermediate page one more poll to pick up "done"

--- a/tests/test_device_auth.py
+++ b/tests/test_device_auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from unittest import mock
 
@@ -16,6 +17,17 @@ from ya_passport_auth.exceptions import (
 )
 
 from music_assistant.providers.yandex_music.device_auth import perform_device_auth
+
+
+@pytest.fixture(autouse=True)
+def skip_grace_sleep() -> mock.AsyncMock:
+    """Bypass the post-auth grace ``asyncio.sleep`` so tests run instantly."""
+    with mock.patch(
+        "music_assistant.providers.yandex_music.device_auth.asyncio.sleep",
+        new=mock.AsyncMock(),
+    ) as patched:
+        yield patched
+
 
 # -- helpers -------------------------------------------------------------------
 
@@ -108,10 +120,6 @@ async def test_perform_device_auth_serves_intermediate_page_and_cleans_up() -> N
             "music_assistant.providers.yandex_music.device_auth.AuthenticationHelper",
             return_value=mock_auth_helper,
         ),
-        mock.patch(
-            "music_assistant.providers.yandex_music.device_auth.asyncio.sleep",
-            new=mock.AsyncMock(),
-        ),
     ):
         mock_create.return_value.__aenter__ = mock.AsyncMock(return_value=mock_client)
         mock_create.return_value.__aexit__ = mock.AsyncMock(return_value=False)
@@ -162,10 +170,6 @@ async def test_perform_device_auth_status_endpoint_reports_done_after_success() 
             "music_assistant.providers.yandex_music.device_auth.AuthenticationHelper",
             return_value=mock_auth_helper,
         ),
-        mock.patch(
-            "music_assistant.providers.yandex_music.device_auth.asyncio.sleep",
-            new=mock.AsyncMock(),
-        ),
     ):
         mock_create.return_value.__aenter__ = mock.AsyncMock(return_value=mock_client)
         mock_create.return_value.__aexit__ = mock.AsyncMock(return_value=False)
@@ -181,6 +185,97 @@ async def test_perform_device_auth_status_endpoint_reports_done_after_success() 
     response = await status_handler(mock.MagicMock())
     payload = json.loads(response.body)
     assert payload["state"] == "done"
+
+
+async def test_perform_device_auth_status_reports_failed_on_error(
+    skip_grace_sleep: mock.AsyncMock,
+) -> None:
+    """When poll fails, status endpoint reports failed and grace sleep still fires.
+
+    Otherwise the page would race with route teardown and only ever see 404s
+    instead of the 'failed' message.
+    """
+    session = _make_device_session()
+    mock_client = mock.AsyncMock()
+    mock_client.start_device_login.return_value = session
+    mock_client.poll_device_until_confirmed.side_effect = DeviceCodeTimeoutError("expired")
+
+    mock_mass = mock.MagicMock()
+    mock_mass.webserver.base_url = "http://ma.local:8095"
+    mock_auth_helper = mock.AsyncMock()
+
+    status_handlers: list = []
+
+    def _capture(path: str, handler, _method: str) -> None:
+        if path.endswith("/status"):
+            status_handlers.append(handler)
+
+    mock_mass.webserver.register_dynamic_route.side_effect = _capture
+
+    with (
+        mock.patch(
+            "music_assistant.providers.yandex_music.device_auth.PassportClient.create",
+        ) as mock_create,
+        mock.patch(
+            "music_assistant.providers.yandex_music.device_auth.AuthenticationHelper",
+            return_value=mock_auth_helper,
+        ),
+    ):
+        mock_create.return_value.__aenter__ = mock.AsyncMock(return_value=mock_client)
+        mock_create.return_value.__aexit__ = mock.AsyncMock(return_value=False)
+
+        with pytest.raises(LoginFailed, match="timed out"):
+            await perform_device_auth(mock_mass, "session_fail")
+
+    assert status_handlers, "status handler should have been registered"
+    response = await status_handlers[0](mock.MagicMock())
+    payload = json.loads(response.body)
+    assert payload["state"] == "failed"
+    # Grace sleep must fire on failure so the page can observe "failed" before teardown.
+    skip_grace_sleep.assert_awaited()
+
+
+async def test_perform_device_auth_does_not_mark_cancellation_as_failure(
+    skip_grace_sleep: mock.AsyncMock,
+) -> None:
+    """CancelledError must propagate without marking state as 'failed' or sleeping."""
+    session = _make_device_session()
+    mock_client = mock.AsyncMock()
+    mock_client.start_device_login.return_value = session
+    mock_client.poll_device_until_confirmed.side_effect = asyncio.CancelledError()
+
+    mock_mass = mock.MagicMock()
+    mock_mass.webserver.base_url = "http://ma.local:8095"
+    mock_auth_helper = mock.AsyncMock()
+
+    status_handlers: list = []
+
+    def _capture(path: str, handler, _method: str) -> None:
+        if path.endswith("/status"):
+            status_handlers.append(handler)
+
+    mock_mass.webserver.register_dynamic_route.side_effect = _capture
+
+    with (
+        mock.patch(
+            "music_assistant.providers.yandex_music.device_auth.PassportClient.create",
+        ) as mock_create,
+        mock.patch(
+            "music_assistant.providers.yandex_music.device_auth.AuthenticationHelper",
+            return_value=mock_auth_helper,
+        ),
+    ):
+        mock_create.return_value.__aenter__ = mock.AsyncMock(return_value=mock_client)
+        mock_create.return_value.__aexit__ = mock.AsyncMock(return_value=False)
+
+        with pytest.raises(asyncio.CancelledError):
+            await perform_device_auth(mock_mass, "session_cancel")
+
+    assert status_handlers, "status handler should have been registered"
+    response = await status_handlers[0](mock.MagicMock())
+    payload = json.loads(response.body)
+    assert payload["state"] == "pending"
+    skip_grace_sleep.assert_not_awaited()
 
 
 async def test_perform_device_auth_route_handler_renders_code_and_url() -> None:

--- a/tests/test_device_auth.py
+++ b/tests/test_device_auth.py
@@ -85,7 +85,7 @@ async def test_perform_device_auth_returns_three_tokens() -> None:
 
 
 async def test_perform_device_auth_serves_intermediate_page_and_cleans_up() -> None:
-    """A temporary HTML page is registered on MA's webserver and unregistered after."""
+    """A temporary HTML page + status endpoint are registered and unregistered after."""
     session = _make_device_session(
         user_code="WXYZ-9999",
         verification_url="https://oauth.yandex.ru/device",
@@ -107,6 +107,10 @@ async def test_perform_device_auth_serves_intermediate_page_and_cleans_up() -> N
             "music_assistant.providers.yandex_music.device_auth.AuthenticationHelper",
             return_value=mock_auth_helper,
         ),
+        mock.patch(
+            "music_assistant.providers.yandex_music.device_auth.asyncio.sleep",
+            new=mock.AsyncMock(),
+        ),
     ):
         mock_create.return_value.__aenter__ = mock.AsyncMock(return_value=mock_client)
         mock_create.return_value.__aexit__ = mock.AsyncMock(return_value=False)
@@ -114,14 +118,70 @@ async def test_perform_device_auth_serves_intermediate_page_and_cleans_up() -> N
         await perform_device_auth(mock_mass, "session_1")
 
     expected_path = "/yandex_music/device_code/session_1"
-    mock_mass.webserver.register_dynamic_route.assert_called_once()
-    register_args = mock_mass.webserver.register_dynamic_route.call_args
-    assert register_args.args[0] == expected_path
-    assert register_args.args[2] == "GET"
-    mock_mass.webserver.unregister_dynamic_route.assert_called_once_with(expected_path, "GET")
+    expected_status_path = f"{expected_path}/status"
+
+    registered_paths = [
+        (c.args[0], c.args[2]) for c in mock_mass.webserver.register_dynamic_route.call_args_list
+    ]
+    assert (expected_path, "GET") in registered_paths
+    assert (expected_status_path, "GET") in registered_paths
+
+    unregistered_paths = [
+        c.args for c in mock_mass.webserver.unregister_dynamic_route.call_args_list
+    ]
+    assert (expected_path, "GET") in unregistered_paths
+    assert (expected_status_path, "GET") in unregistered_paths
+
     mock_auth_helper.__aenter__.return_value.send_url.assert_called_once_with(
         f"http://ma.local:8095{expected_path}"
     )
+
+
+async def test_perform_device_auth_status_endpoint_reports_done_after_success() -> None:
+    """The status endpoint reports state=done after the device flow completes.
+
+    Without this the popup window (opened via target=_blank) has no signal to
+    close itself after the user confirms the code.
+    """
+    import json
+
+    session = _make_device_session()
+    creds = _make_credentials()
+    mock_client = mock.AsyncMock()
+    mock_client.start_device_login.return_value = session
+    mock_client.poll_device_until_confirmed.return_value = creds
+
+    mock_mass = mock.MagicMock()
+    mock_mass.webserver.base_url = "http://ma.local:8095"
+    mock_auth_helper = mock.AsyncMock()
+
+    with (
+        mock.patch(
+            "music_assistant.providers.yandex_music.device_auth.PassportClient.create",
+        ) as mock_create,
+        mock.patch(
+            "music_assistant.providers.yandex_music.device_auth.AuthenticationHelper",
+            return_value=mock_auth_helper,
+        ),
+        mock.patch(
+            "music_assistant.providers.yandex_music.device_auth.asyncio.sleep",
+            new=mock.AsyncMock(),
+        ),
+    ):
+        mock_create.return_value.__aenter__ = mock.AsyncMock(return_value=mock_client)
+        mock_create.return_value.__aexit__ = mock.AsyncMock(return_value=False)
+
+        await perform_device_auth(mock_mass, "session_xyz")
+
+    status_call = next(
+        c
+        for c in mock_mass.webserver.register_dynamic_route.call_args_list
+        if c.args[0].endswith("/status")
+    )
+    status_handler = status_call.args[1]
+    response = await status_handler(mock.MagicMock())
+    payload = json.loads(response.body)
+    assert payload["state"] == "done"
 
 
 async def test_perform_device_auth_route_handler_renders_code_and_url() -> None:
@@ -153,7 +213,12 @@ async def test_perform_device_auth_route_handler_renders_code_and_url() -> None:
 
         await perform_device_auth(mock_mass, "session_1")
 
-    handler = mock_mass.webserver.register_dynamic_route.call_args.args[1]
+    page_call = next(
+        c
+        for c in mock_mass.webserver.register_dynamic_route.call_args_list
+        if not c.args[0].endswith("/status")
+    )
+    handler = page_call.args[1]
     response = await handler(mock.MagicMock())
     body = response.text
     assert body is not None
@@ -188,9 +253,11 @@ async def test_perform_device_auth_timeout_raises_login_failed() -> None:
         with pytest.raises(LoginFailed, match="timed out"):
             await perform_device_auth(mock_mass, "session_1")
 
-    mock_mass.webserver.unregister_dynamic_route.assert_called_once_with(
-        "/yandex_music/device_code/session_1", "GET"
-    )
+    unregistered_paths = [
+        c.args for c in mock_mass.webserver.unregister_dynamic_route.call_args_list
+    ]
+    assert ("/yandex_music/device_code/session_1", "GET") in unregistered_paths
+    assert ("/yandex_music/device_code/session_1/status", "GET") in unregistered_paths
 
 
 async def test_perform_device_auth_ya_passport_error_raises_login_failed() -> None:

--- a/tests/test_device_auth.py
+++ b/tests/test_device_auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from unittest import mock
 
 import pytest
@@ -143,8 +144,6 @@ async def test_perform_device_auth_status_endpoint_reports_done_after_success() 
     Without this the popup window (opened via target=_blank) has no signal to
     close itself after the user confirms the code.
     """
-    import json
-
     session = _make_device_session()
     creds = _make_credentials()
     mock_client = mock.AsyncMock()


### PR DESCRIPTION
## Summary
Two UX bugs in the Device Flow intermediate page (added in #104):

1. **Code and instructions were unreadable.** The old CSS relied on \`@media (prefers-color-scheme: dark)\` to theme body + card together, but in practice the page rendered as *white card + white text* for some users (see screenshot) — the text colour flipped to dark-mode white while the card stayed light, killing contrast. Force \`color-scheme: light\` and set explicit, high-contrast colours on every element so the page is always readable regardless of the surrounding frame's theme.

2. **Popup window never closed after authorization.** MA's frontend opens the auth URL in a new tab (\`target=\"_blank\"\`), so once the user confirms the code on Yandex the backend obtains the creds, closes the \`AuthenticationHelper\`, and finishes silently — the user is left staring at the old code page. Register a small \`/status\` endpoint alongside the page; the page polls it every 2 s and, once the backend reports \`state=done\`, shows \"Authorization successful — you can close this window.\" and attempts \`window.close()\`. On failure it shows an error message. A 3-second grace sleep keeps the status endpoint reachable for one more poll before the routes are torn down.

## Test plan
- [x] Unit tests updated; added coverage for the status endpoint and its final state. \`pytest tests/test_device_auth.py\` → 8 passed.
- [x] Full suite: \`pytest --ignore=tests/test_integration.py\` → 167 passed.
- [ ] Manual: re-run device auth in MA dev addon, confirm page is readable and closes itself after the user confirms the code in Yandex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)