### PR TITLE
chore(changelog): remove duplicate 3.3.0 and 3.3.1 entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,22 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- changelog entries will be added here by release workflow -->
 
-## [3.3.1] - 2026-04-23
-
-- fix(search): apply `limit` per bucket after `classify_album` so audiobooks aren't dropped when the top `limit` results are music albums (and vice versa)
-
----
-
-## [3.3.0] - 2026-04-23
-
-- feat(audiobook): sync playback progress to Yandex via `play_audio` from `on_played` / `on_streamed` so position is visible across Yandex clients; propagate `album.listening_finished` to `Audiobook.fully_played` (`974b675`)
-- feat(search): map `MediaType.AUDIOBOOK` to Yandex `album` search and split results via `classify_album`; dedup requested types so `ALBUM + AUDIOBOOK` issues one API call (`974b675`)
-- feat(browse): add *My Audiobooks* / *My Podcasts* folders to Collection (RU+EN) and route their subpaths through base `MusicProvider.browse` (`974b675`)
-- refactor(audiobook): extract `_extract_chapter_map_from_album` helper, clear caches on `on_streamed`/`unload`, widen error swallowing in `play_audio` / `_report_audiobook_progress` (`7c64a51`)
-- chore(changelog): reorder entries newest-first (`c87ac16`)
-
----
-
 ## [3.2.1] - 2026-04-22
 
 - fix(audiobook): wire seek through can_seek and bound chapter failures (`40bdc9b`)


### PR DESCRIPTION
## Summary

After #115 and #116 merged, the release workflow's auto-generated `[3.3.0]` and `[3.3.1]` changelog sections collided with the hand-written ones I had included in each PR, producing duplicate headings and an out-of-order layout on `dev`.

This PR drops the manual copies and leaves only the workflow-generated entries. Going forward I won't touch `CHANGELOG.md` in PRs — only `VERSION`.

## Test plan

- [x] `CHANGELOG.md` contains exactly one `## [3.3.0]` and one `## [3.3.1]` section (the workflow-generated ones).
- [x] Release-workflow insertion marker (`<!-- changelog entries will be added here by release workflow -->`) preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)