### PR TITLE
fix(presets): drop whitespace-only dropdown values + strip surrounding spaces

### DIFF
--- a/provider/presets.py
+++ b/provider/presets.py
@@ -15,9 +15,12 @@ def parse_stored_presets(raw: object) -> list[dict[str, str]]:
 
     Only entries with a non-empty ``name`` string are kept. The optional
     ``diversity`` / ``moodEnergy`` / ``language`` fields are carried through
-    as long as they are non-empty strings. Any other keys are dropped.
-    Malformed JSON, non-list roots or non-dict items yield an empty list —
-    the UI treats that as "no presets yet".
+    as long as they are non-empty *after stripping whitespace* — Yandex
+    would reject rotor seeds like ``settingDiversity: `` (space) with a 4xx,
+    so we never pass such values through. Stripped form is stored so the
+    downstream seed builder gets the canonical value. Any other keys are
+    dropped. Malformed JSON, non-list roots or non-dict items yield an
+    empty list — the UI treats that as "no presets yet".
 
     :param raw: Value read from the ``wave_presets_data`` config entry.
     :return: List of sanitised preset dicts in source order.
@@ -40,7 +43,9 @@ def parse_stored_presets(raw: object) -> list[dict[str, str]]:
         clean: dict[str, str] = {"name": name.strip()}
         for key in ("diversity", "moodEnergy", "language"):
             val = item.get(key)
-            if isinstance(val, str) and val:
-                clean[key] = val
+            if isinstance(val, str):
+                val = val.strip()
+                if val:
+                    clean[key] = val
         result.append(clean)
     return result

--- a/tests/test_my_wave.py
+++ b/tests/test_my_wave.py
@@ -481,6 +481,32 @@ def test_get_user_wave_presets_skips_items_without_name() -> None:
     ]
 
 
+def test_get_user_wave_presets_drops_whitespace_only_values() -> None:
+    """Whitespace-only dropdown values (e.g. hand-edited JSON) are treated as empty.
+
+    Yandex rejects ``settingDiversity:`` with a 4xx, so the parser must not
+    propagate such values. Valid values are also stripped to their canonical
+    form so the downstream rotor seed builder always gets the stored string
+    without surrounding whitespace.
+    """
+    provider = Mock(spec=YandexMusicProvider)
+    provider.config = _preset_config(
+        {
+            "wave_presets_data": (
+                '[{"name": "WS-only", "diversity": "   ",'
+                ' "moodEnergy": "\\t", "language": ""},'
+                ' {"name": "Trim", "diversity": "  discover  "}]'
+            ),
+        }
+    )
+    provider.logger = Mock()
+
+    assert YandexMusicProvider._get_user_wave_presets(provider) == [
+        {"name": "WS-only"},
+        {"name": "Trim", "diversity": "discover"},
+    ]
+
+
 # -- save / delete preset actions --------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Addresses [Copilot review comment on music-assistant/server#3606](https://github.com/music-assistant/server/pull/3606#discussion_r3131241793) against the upstream sync of v3.4.0.

`parse_stored_presets` validated optional dropdown fields with `isinstance(val, str) and val`, so a hand-edited JSON with a whitespace-only value (e.g. `" "`) passed validation and propagated into the rotor seed — Yandex then rejects `settingDiversity:` with a 4xx, silently losing the preset.

## Change

Strip whitespace before the empty-check, keep the stripped form when the value is valid. Whitespace-only → treated as empty → skipped. Leading/trailing spaces on a valid value → normalised to canonical.

## Test plan

- [x] `pytest` — 255/255 (+1 new test in `test_my_wave.py::test_get_user_wave_presets_drops_whitespace_only_values` exercising both the whitespace-only drop and the leading/trailing strip)
- [x] `ruff check` / `mypy` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)