### PR TITLE
reverse-sync: Cache negative results in @use_cache and avoid the SWR double read (#4616)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -513,3 +513,4 @@ No changes.
 ## 2026-01-28
 
 - feat: add Yandex Music provider (music-assistant/server#3002)
+- Reverse-synced upstream PR #4616 (WIP)

--- a/specs/inprogress/reverse-sync-pr4616.md
+++ b/specs/inprogress/reverse-sync-pr4616.md
@@ -1,0 +1,9 @@
+# Reverse-sync: upstream PR #4616
+
+WIP=1
+
+Ported from music-assistant/server#4616 into `yandex_music`.
+
+## Summary
+
+_TODO: describe the change._

--- a/tests/test_recommendations.py
+++ b/tests/test_recommendations.py
@@ -53,6 +53,7 @@ def provider_mock() -> Mock:
     provider.mass.metadata.locale = "en_US"
     provider.mass.cache = AsyncMock()
     provider.mass.cache.get = AsyncMock(return_value=None)  # Cache always misses
+    provider.mass.cache.get_with_freshness = AsyncMock(return_value=(None, False, False))
     provider.mass.cache.set = AsyncMock()
 
     # Mock _get_browse_names to return EN names

--- a/tests/test_search_audiobooks.py
+++ b/tests/test_search_audiobooks.py
@@ -57,6 +57,7 @@ def provider_mock() -> Mock:
     provider.mass = Mock()
     provider.mass.cache = AsyncMock()
     provider.mass.cache.get = AsyncMock(return_value=None)
+    provider.mass.cache.get_with_freshness = AsyncMock(return_value=(None, False, False))
     provider.mass.cache.set = AsyncMock()
     return provider
 


### PR DESCRIPTION
Reverse-sync of upstream PR https://github.com/music-assistant/server/pull/4616 into the `yandex_music` provider.

Original author: @marcelveldt (credited via `Co-authored-by`).

**Maintainer-owned files were NOT touched** — review `VERSION` and `translations/en.json` manually if the upstream change implies a bump.

- [ ] Spec filled in (`specs/inprogress/`)
- [ ] CHANGELOG entry finalized
- [ ] Tests pass locally