### PR TITLE
chore(specs): move spec 0002 to done after PR #184 merge

### DIFF
--- a/specs/done/0002-device-code-page-ux.md
+++ b/specs/done/0002-device-code-page-ux.md
@@ -2,7 +2,7 @@
 id: "0002"
 title: "Device-code login page UX overhaul"
 size: L
-status: inprogress
+status: done
 priority: P1
 effort_minutes: 90
 feature_id:


### PR DESCRIPTION
Housekeeping mandated by the spec lifecycle (`specs/feature-spec.md`): PR #184 implementing spec 0002 has merged, so the spec moves `inprogress` → `done` with `status: done`.

No spec required because this is a `chore:` (spec-lifecycle housekeeping only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)