### PR TITLE
fix(compat): catch up with upstream MA model changes

### DIFF
--- a/provider/parsers.py
+++ b/provider/parsers.py
@@ -17,6 +17,7 @@ from music_assistant_models.media_items import (
     Artist,
     Audiobook,
     AudioFormat,
+    ItemMapping,
     MediaItemImage,
     Playlist,
     Podcast,
@@ -656,7 +657,7 @@ def parse_audiobook(provider: YandexMusicProvider, album_obj: YandexAlbum) -> Au
         if label_name:
             publisher = label_name
 
-    authors: UniqueList[str | Artist] = UniqueList()
+    authors: UniqueList[Artist | ItemMapping | str] = UniqueList()
     if album_obj.artists:
         for artist in album_obj.artists:
             if artist.name:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ ignore-words-list = "provid,hass,followings,childs,explict,additionals,commitish
 
 # >>> ma-provider-tools sync (mypy) — DO NOT EDIT >>>
 [tool.mypy]
-python_version = "3.12"
+python_version = "3.14"
 platform = "linux"
 follow_imports = "silent"
 ignore_missing_imports = true

--- a/tests/__snapshots__/test_parsers.ambr
+++ b/tests/__snapshots__/test_parsers.ambr
@@ -13,6 +13,7 @@
     'media_type': 'album',
     'metadata': dict({
       'chapters': None,
+      'collections': None,
       'copyright': None,
       'description': None,
       'description_language': None,
@@ -59,7 +60,6 @@
       }),
     ]),
     'sort_name': 'test album',
-    'translation_key': None,
     'uri': 'yandex_music_instance://album/300',
     'version': '',
     'year': 2020,
@@ -77,6 +77,7 @@
     'media_type': 'artist',
     'metadata': dict({
       'chapters': None,
+      'collections': None,
       'copyright': None,
       'description': None,
       'description_language': None,
@@ -123,7 +124,6 @@
       }),
     ]),
     'sort_name': 'test artist',
-    'translation_key': None,
     'uri': 'yandex_music_instance://artist/100',
     'version': '',
   })
@@ -140,6 +140,7 @@
     'media_type': 'artist',
     'metadata': dict({
       'chapters': None,
+      'collections': None,
       'copyright': None,
       'description': None,
       'description_language': None,
@@ -194,7 +195,6 @@
       }),
     ]),
     'sort_name': 'artist with cover',
-    'translation_key': None,
     'uri': 'yandex_music_instance://artist/200',
     'version': '',
   })
@@ -212,6 +212,7 @@
     'media_type': 'playlist',
     'metadata': dict({
       'chapters': None,
+      'collections': None,
       'copyright': None,
       'description': None,
       'description_language': None,
@@ -263,6 +264,7 @@
       'track',
     ]),
     'translation_key': None,
+    'translation_params': None,
     'uri': 'yandex_music_instance://playlist/12345:3',
     'version': '',
   })
@@ -280,6 +282,7 @@
     'media_type': 'playlist',
     'metadata': dict({
       'chapters': None,
+      'collections': None,
       'copyright': None,
       'description': 'A shared playlist',
       'description_language': None,
@@ -331,6 +334,7 @@
       'track',
     ]),
     'translation_key': None,
+    'translation_params': None,
     'uri': 'yandex_music_instance://playlist/99999:1',
     'version': '',
   })
@@ -353,6 +357,7 @@
     'media_type': 'track',
     'metadata': dict({
       'chapters': None,
+      'collections': None,
       'copyright': None,
       'description': None,
       'description_language': None,
@@ -400,7 +405,6 @@
     ]),
     'sort_name': 'test track',
     'track_number': 0,
-    'translation_key': None,
     'uri': 'yandex_music_instance://track/400',
     'version': '',
   })
@@ -420,6 +424,7 @@
       'media_type': 'album',
       'metadata': dict({
         'chapters': None,
+        'collections': None,
         'copyright': None,
         'description': None,
         'description_language': None,
@@ -474,7 +479,6 @@
         }),
       ]),
       'sort_name': 'track album',
-      'translation_key': None,
       'uri': 'yandex_music_instance://album/20',
       'version': '',
       'year': None,
@@ -491,6 +495,7 @@
         'media_type': 'artist',
         'metadata': dict({
           'chapters': None,
+          'collections': None,
           'copyright': None,
           'description': None,
           'description_language': None,
@@ -537,7 +542,6 @@
           }),
         ]),
         'sort_name': 'track artist',
-        'translation_key': None,
         'uri': 'yandex_music_instance://artist/10',
         'version': '',
       }),
@@ -555,6 +559,7 @@
     'media_type': 'track',
     'metadata': dict({
       'chapters': None,
+      'collections': None,
       'copyright': None,
       'description': None,
       'description_language': None,
@@ -610,7 +615,6 @@
     ]),
     'sort_name': 'track with album',
     'track_number': 0,
-    'translation_key': None,
     'uri': 'yandex_music_instance://track/500',
     'version': '',
   })

--- a/uv.lock
+++ b/uv.lock
@@ -1166,7 +1166,7 @@ requires-dist = [
     { name = "pytest-aiohttp", marker = "extra == 'test'", specifier = ">=1.1" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.24" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=7.0" },
-    { name = "ruff", marker = "extra == 'test'", specifier = ">=0.14" },
+    { name = "ruff", marker = "extra == 'test'", specifier = ">=0.14,<0.15" },
     { name = "syrupy", marker = "extra == 'test'", specifier = ">=5.0" },
     { name = "ya-passport-auth", specifier = "==1.4.1" },
     { name = "yandex-music", specifier = "==3.0.0" },


### PR DESCRIPTION
## Summary

Weekly CI on `dev` has been red since 2026-06-22 because upstream `music-assistant` moved on (models 1.1.125 → 1.1.154, Python 3.14). This PR catches the provider up:

- **Parser snapshots refreshed** (7): model serialization gained `collections` / `translation_params` and dropped `translation_key` at some levels. Shape-only changes, all new fields `None`; parser logic untouched — verified by reproducing the exact CI failure set locally against a fresh `music-assistant@dev` install.
- **`Audiobook.authors` annotation widened** to `UniqueList[Artist | ItemMapping | str]` per the new models signature (fixes the CI mypy error in `parsers.py`).
- **mypy `python_version` 3.12 → 3.14** (provider-specific carve-out per `CLAUDE.md`): upstream targets 3.14 and uses 3.14-only syntax, so type-checking against it requires the newer target.
- `uv.lock` refresh (ruff specifier).

No spec required: `fix:`/compat only, no behaviour change.

## Why it matters

- Restores a green Test baseline on `dev` — currently every PR shows the same 8 unrelated failures.
- Unblocks the release pipeline for the already-merged **v3.6.0** (device-code UX overhaul), which is gated on the Test workflow.
- Prerequisite for the strings.json localization port (next PR): verifying it requires a current MA in the dev environment.

## Testing

- `uv run pytest` — 378 passed against music-assistant@dev (models 1.1.154).
- `pre-commit run --all-files` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)