### PR TITLE
chore(specs): move spec 0004 to done after PR #195 merge

### DIFF
--- a/specs/done/0004-device-page-strings.md
+++ b/specs/done/0004-device-page-strings.md
@@ -2,7 +2,7 @@
 id: "0004"
 title: "Device-code page strings through the MA translations pipeline"
 size: M
-status: inprogress
+status: done
 priority: P1
 effort_minutes: 40
 feature_id:


### PR DESCRIPTION
Spec-lifecycle housekeeping: PR #195 implementing spec 0004 has merged.

No spec required because this is a `chore:` (spec-lifecycle housekeeping only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)