### PR TITLE
chore(deps): bump ya-passport-auth to 1.5.0

### DIFF
--- a/provider/manifest.json
+++ b/provider/manifest.json
@@ -7,6 +7,6 @@
   "codeowners": ["@TrudenBoy"],
   "credits": ["[yandex-music-api](https://github.com/MarshalX/yandex-music-api)"],
   "documentation": "https://music-assistant.io/music-providers/yandex-music/",
-  "requirements": ["yandex-music==3.0.0", "ya-passport-auth==1.4.1"],
+  "requirements": ["yandex-music==3.0.0", "ya-passport-auth==1.5.0"],
   "multi_instance": true
 }


### PR DESCRIPTION
Phase 0 of the auth-unification plan: single exact `ya-passport-auth==1.5.0` across all yandex providers (companion to trudenboy/ma-provider-tools#106).

`manifest.json` only. The synced `pyproject.toml` dependency (`==1.4.1`) is owned by ma-provider-tools and arrives via `distribute.yml` after #106 merges; `uv.lock` will be regenerated then. 389 tests pass locally against 1.5.0.

Note: this repo is inlined upstream — the pin change flows to `music-assistant/server` with the next sync and will re-trigger dependency review there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)