### PR TITLE
test: upstream-layout rewrite safety — port #208 leftovers, harden and cover the conftest aliasing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ def _alias_working_tree_provider(provider_dir: Path) -> None:
 
     :param provider_dir: Path to the ``provider`` working-tree directory.
     """
+    provider_dir = provider_dir.resolve()
     if not provider_dir.is_dir():
         return
     existing = sys.modules.get(_PROVIDER_PKG)
@@ -49,23 +50,28 @@ def _alias_working_tree_provider(provider_dir: Path) -> None:
         raise ImportError(f"cannot load provider package from {provider_dir}")
     module = importlib.util.module_from_spec(spec)
     sys.modules[_PROVIDER_PKG] = module
-    spec.loader.exec_module(module)
+    try:
+        spec.loader.exec_module(module)
+    except BaseException:
+        # Mirror the import machinery: a failed exec must not leave a
+        # half-initialized module registered under the package name.
+        del sys.modules[_PROVIDER_PKG]
+        raise
     # Regular imports also bind the submodule as an attribute of its parent
     # package; monkeypatch and friends resolve dotted paths via getattr.
     parent = importlib.import_module("music_assistant.providers")
     setattr(parent, "yandex_music", module)  # noqa: B010
 
 
-_alias_working_tree_provider(Path(__file__).resolve().parent.parent / "provider")
+# The assignment + is_dir() shape (not a bare call argument) keeps this
+# dereference visible to the rewrite-safe Rule C gate in CI.
+_PROVIDER_DIR = Path(__file__).resolve().parent.parent / "provider"
+if _PROVIDER_DIR.is_dir():
+    _alias_working_tree_provider(_PROVIDER_DIR)
 
 
 def provider_dir() -> Path:
-    """Directory of the provider package under test, in either layout.
-
-    Resolves through the imported package: in the provider repo the aliasing
-    above points it at the working tree's ``provider/``; upstream it is the
-    inlined ``music_assistant/providers/yandex_music/`` checkout itself.
-    """
+    """Directory of the provider package under test, in either layout."""
     pkg = importlib.import_module(_PROVIDER_PKG)
     pkg_file = pkg.__file__
     assert pkg_file is not None  # a real package always has a file

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import importlib.util
 import logging
 import sys
@@ -11,41 +12,64 @@ import pytest
 from music_assistant_models.enums import MediaType
 from music_assistant_models.media_items import ItemMapping
 
-# In the provider-repo layout, tests must exercise the working tree, not the
-# provider snapshot baked into the venv's music_assistant install — alias the
-# local ``provider`` package onto the upstream import path before any test
-# module imports it. In the upstream (inlined) layout there is no sibling
-# ``provider/`` directory and the package under test IS the checkout itself,
-# so the aliasing must no-op instead of failing collection.
-_PROVIDER_DIR = Path(__file__).resolve().parent.parent / "provider"
 _PROVIDER_PKG = "music_assistant.providers.yandex_music"
-_existing = sys.modules.get(_PROVIDER_PKG)
-if not _PROVIDER_DIR.is_dir():
-    pass  # upstream layout — nothing to alias
-elif _existing is not None:
-    # Something imported the provider before this conftest ran — silently
-    # testing the venv snapshot instead of the working tree must be fatal.
-    _loaded_from = Path(getattr(_existing, "__file__", "") or "").resolve().parent
-    if _loaded_from != _PROVIDER_DIR:
-        raise RuntimeError(
-            f"{_PROVIDER_PKG} was already imported from {_loaded_from}; "
-            f"tests must run against {_PROVIDER_DIR}"
-        )
-else:
-    _spec = importlib.util.spec_from_file_location(
+
+
+def _alias_working_tree_provider(provider_dir: Path) -> None:
+    """
+    Alias the ``provider`` working-tree package onto the upstream import path.
+
+    In the provider-repo layout, tests must exercise the working tree, not the
+    provider snapshot baked into the venv's music_assistant install. In the
+    upstream (inlined) layout there is no sibling ``provider/`` directory and
+    the package under test IS the checkout itself, so the aliasing must no-op
+    instead of failing collection.
+
+    :param provider_dir: Path to the ``provider`` working-tree directory.
+    """
+    if not provider_dir.is_dir():
+        return
+    existing = sys.modules.get(_PROVIDER_PKG)
+    if existing is not None:
+        # Something imported the provider before this conftest ran — silently
+        # testing the venv snapshot instead of the working tree must be fatal.
+        loaded_from = Path(getattr(existing, "__file__", "") or "").resolve().parent
+        if loaded_from != provider_dir:
+            raise RuntimeError(
+                f"{_PROVIDER_PKG} was already imported from {loaded_from}; "
+                f"tests must run against {provider_dir}"
+            )
+        return
+    spec = importlib.util.spec_from_file_location(
         _PROVIDER_PKG,
-        _PROVIDER_DIR / "__init__.py",
-        submodule_search_locations=[str(_PROVIDER_DIR)],
+        provider_dir / "__init__.py",
+        submodule_search_locations=[str(provider_dir)],
     )
-    if _spec is None or _spec.loader is None:
-        raise ImportError(f"cannot load provider package from {_PROVIDER_DIR}")
-    _module = importlib.util.module_from_spec(_spec)
-    sys.modules[_PROVIDER_PKG] = _module
-    _spec.loader.exec_module(_module)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load provider package from {provider_dir}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[_PROVIDER_PKG] = module
+    spec.loader.exec_module(module)
     # Regular imports also bind the submodule as an attribute of its parent
     # package; monkeypatch and friends resolve dotted paths via getattr.
-    _parent = importlib.import_module("music_assistant.providers")
-    setattr(_parent, "yandex_music", _module)  # noqa: B010
+    parent = importlib.import_module("music_assistant.providers")
+    setattr(parent, "yandex_music", module)  # noqa: B010
+
+
+_alias_working_tree_provider(Path(__file__).resolve().parent.parent / "provider")
+
+
+def provider_dir() -> Path:
+    """Directory of the provider package under test, in either layout.
+
+    Resolves through the imported package: in the provider repo the aliasing
+    above points it at the working tree's ``provider/``; upstream it is the
+    inlined ``music_assistant/providers/yandex_music/`` checkout itself.
+    """
+    pkg = importlib.import_module(_PROVIDER_PKG)
+    pkg_file = pkg.__file__
+    assert pkg_file is not None  # a real package always has a file
+    return Path(pkg_file).resolve().parent
 
 
 class ProviderStub:

--- a/tests/test_browse_collection.py
+++ b/tests/test_browse_collection.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
@@ -12,11 +11,9 @@ from music_assistant_models.media_items import BrowseFolder
 
 from music_assistant.providers.yandex_music.provider import YandexMusicProvider
 
-_STRINGS = json.loads(
-    (Path(__file__).resolve().parent.parent / "provider" / "strings.json").read_text(
-        encoding="utf-8"
-    )
-)
+from .conftest import provider_dir
+
+_STRINGS = json.loads((provider_dir() / "strings.json").read_text(encoding="utf-8"))
 
 
 def _make_provider_mock(features: set[ProviderFeature]) -> Mock:

--- a/tests/test_conftest_aliasing.py
+++ b/tests/test_conftest_aliasing.py
@@ -6,17 +6,9 @@ import sys
 import types
 from pathlib import Path
 
-_PROVIDER_PKG = "music_assistant.providers.yandex_music"
+import pytest
 
-
-def _conftest_module() -> types.ModuleType:
-    """Return the already-imported conftest module that sits next to this file."""
-    conftest_path = Path(__file__).resolve().parent / "conftest.py"
-    for module in list(sys.modules.values()):
-        module_file = getattr(module, "__file__", None)
-        if module_file and Path(module_file).resolve() == conftest_path:
-            return module
-    raise AssertionError(f"conftest module for {conftest_path} is not loaded")
+from .conftest import _PROVIDER_PKG, _alias_working_tree_provider
 
 
 def test_aliasing_is_noop_without_provider_working_tree(tmp_path: Path) -> None:
@@ -26,9 +18,56 @@ def test_aliasing_is_noop_without_provider_working_tree(tmp_path: Path) -> None:
     That is the upstream repo layout: the aliasing must silently no-op there
     instead of crashing test collection.
     """
-    conftest = _conftest_module()
     before = sys.modules.get(_PROVIDER_PKG)
 
-    conftest._alias_working_tree_provider(tmp_path / "provider")
+    _alias_working_tree_provider(tmp_path / "provider")
 
     assert sys.modules.get(_PROVIDER_PKG) is before
+
+
+def test_aliasing_rejects_preimported_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fail loudly when the provider was already imported from another location."""
+    provider_dir = tmp_path / "provider"
+    provider_dir.mkdir()
+    (provider_dir / "__init__.py").touch()
+    snapshot = types.ModuleType(_PROVIDER_PKG)
+    snapshot.__file__ = str(tmp_path / "venv_snapshot" / "__init__.py")
+    monkeypatch.setitem(sys.modules, _PROVIDER_PKG, snapshot)
+
+    with pytest.raises(RuntimeError, match="already imported"):
+        _alias_working_tree_provider(provider_dir)
+
+
+def test_aliasing_accepts_symlinked_working_tree(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Treat a symlink to the already-imported working tree as the same location."""
+    real_dir = tmp_path / "real_provider"
+    real_dir.mkdir()
+    (real_dir / "__init__.py").touch()
+    link_dir = tmp_path / "provider"
+    link_dir.symlink_to(real_dir, target_is_directory=True)
+    already_imported = types.ModuleType(_PROVIDER_PKG)
+    already_imported.__file__ = str(real_dir / "__init__.py")
+    monkeypatch.setitem(sys.modules, _PROVIDER_PKG, already_imported)
+
+    _alias_working_tree_provider(link_dir)
+
+    assert sys.modules[_PROVIDER_PKG] is already_imported
+
+
+def test_aliasing_unregisters_module_when_exec_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Leave no half-initialized module behind when the package fails to execute."""
+    provider_dir = tmp_path / "provider"
+    provider_dir.mkdir()
+    (provider_dir / "__init__.py").write_text("raise ValueError('boom')\n")
+    monkeypatch.delitem(sys.modules, _PROVIDER_PKG)
+
+    with pytest.raises(ValueError, match="boom"):
+        _alias_working_tree_provider(provider_dir)
+
+    assert _PROVIDER_PKG not in sys.modules

--- a/tests/test_conftest_aliasing.py
+++ b/tests/test_conftest_aliasing.py
@@ -1,0 +1,34 @@
+"""Tests for the working-tree provider aliasing performed in conftest."""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+_PROVIDER_PKG = "music_assistant.providers.yandex_music"
+
+
+def _conftest_module() -> types.ModuleType:
+    """Return the already-imported conftest module that sits next to this file."""
+    conftest_path = Path(__file__).resolve().parent / "conftest.py"
+    for module in list(sys.modules.values()):
+        module_file = getattr(module, "__file__", None)
+        if module_file and Path(module_file).resolve() == conftest_path:
+            return module
+    raise AssertionError(f"conftest module for {conftest_path} is not loaded")
+
+
+def test_aliasing_is_noop_without_provider_working_tree(tmp_path: Path) -> None:
+    """
+    Skip aliasing when the ``provider/`` working tree does not exist.
+
+    That is the upstream repo layout: the aliasing must silently no-op there
+    instead of crashing test collection.
+    """
+    conftest = _conftest_module()
+    before = sys.modules.get(_PROVIDER_PKG)
+
+    conftest._alias_working_tree_provider(tmp_path / "provider")
+
+    assert sys.modules.get(_PROVIDER_PKG) is before

--- a/tests/test_localization.py
+++ b/tests/test_localization.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 from typing import TYPE_CHECKING, cast
 from unittest import mock
 
@@ -17,10 +16,12 @@ from music_assistant.providers.yandex_music.constants import (
 )
 from music_assistant.providers.yandex_music.provider import YandexMusicProvider
 
+from .conftest import provider_dir
+
 if TYPE_CHECKING:
     from music_assistant_models.config_entries import ConfigEntry
 
-_PROVIDER_DIR = Path(__file__).resolve().parent.parent / "provider"
+_PROVIDER_DIR = provider_dir()
 
 # The auth status label is dynamic (three states); it keeps an English
 # fallback in code and localizes via per-state translation keys. The

--- a/tests/test_recommendations.py
+++ b/tests/test_recommendations.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import pathlib
-from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -28,13 +27,11 @@ from music_assistant.providers.yandex_music.constants import (
 )
 from music_assistant.providers.yandex_music.provider import YandexMusicProvider, _WaveState
 
-from .conftest import DE_JSON_CLIENT
+from .conftest import DE_JSON_CLIENT, provider_dir
 
-_RECOMMENDATION_STRINGS = json.loads(
-    (Path(__file__).resolve().parent.parent / "provider" / "strings.json").read_text(
-        encoding="utf-8"
-    )
-)["media"]["recommendations"]
+_RECOMMENDATION_STRINGS = json.loads((provider_dir() / "strings.json").read_text(encoding="utf-8"))[
+    "media"
+]["recommendations"]
 
 
 @pytest.fixture


### PR DESCRIPTION
## What

Finishes the upstream-layout rewrite-safety work started in #208 and hardens the conftest aliasing, so the synced test suite runs green in **both** layouts (provider repo and `music-assistant/server`'s `tests/providers/yandex_music/`).

### 1. Port the unmerged half of #208

#208's squash took only the conftest no-op guard — the branch commit porting `test_browse_collection` / `test_localization` / `test_recommendations` off their sibling-`provider/` paths onto `conftest.provider_dir()` never landed on `dev`. That is why the **rewrite-safe Rule C gate is red on `dev`-based PRs** (3 findings) and why upstream PR music-assistant/server#4690 would still break at collection even after the conftest fix. Ported here as authored on the original branch (`Co-authored-by` preserved).

### 2. Regression coverage for the aliasing (TDD)

The aliasing block is extracted into `_alias_working_tree_provider()` — same behavior, now callable — with four tests: upstream-layout no-op (the #208 incident, written red first), pre-imported-snapshot mismatch, symlinked working tree, and exec-failure cleanup.

### 3. Hardening found by self-review (red → green)

- The already-imported guard compared a resolved path against the caller's as-passed path — a symlinked working tree tripped a spurious mismatch `RuntimeError`. The argument is now resolved first.
- A failing `exec_module()` left a half-initialized module registered in `sys.modules`; it is now unregistered on failure, mirroring the import machinery.
- The module-level dereference keeps the assignment + `is_dir()` shape the Rule C AST checker tracks, instead of a bare call argument it cannot see.
- The regression test binds conftest via `from .conftest import` (the `test_parsers` pattern, valid in both layouts) instead of scanning `sys.modules`, and shares the canonical `_PROVIDER_PKG` constant instead of a shadow copy.

## Notes

- Test-only change (`test:` type) — no changelog entry, no spec required.
- `pytest` (393 passed) and `pre-commit run --all-files` are green locally; this PR should also turn the `rewrite-safe` gate green (it fails on current `dev`).
- The earlier `Lint & Type Check` failure on this PR was a mirror flake (503 from `download.pytorch.org` while installing deps), unrelated to the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
