### PR TITLE
chore: untrack the ma-server gitlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ ma-server.repo
 site/
 .ma-data/
 docs-site/node_modules/
+ma-server/


### PR DESCRIPTION
## What

`ma-server/` is a local convenience checkout of upstream `music-assistant/server`, but it was committed as a bare **gitlink with no `.gitmodules` entry**:

- clones can never populate it, and every CI job logs `fatal: No url found for submodule path 'ma-server' in .gitmodules` (the recurring `git exit 128` warnings in Actions);
- until trudenboy/ma-provider-tools#111, the pipeline's auto-fix step kept committing pointer bumps to it (the `style: auto-fix ruff` commits such as 1205ba1), and its unstageable content modifications red-flagged the gate.

Untrack the gitlink and add `ma-server/` to `.gitignore`. Working-tree checkouts stay untouched; `scripts/setup.sh` uses the workspace-level `ma-server` sibling, not this gitlink.

Test-only/infra change — no changelog entry, no spec required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)