### PR TITLE
refactor(l10n): reference the common catalog for shared auth strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.8.3] - 2026-07-13
+
+### Changed
+
+- The shared authentication texts (login buttons, "Remember session", the device-code login page) now reference Music Assistant's common translation catalog instead of carrying local copies — translations arrive once for all yandex providers. The page title keeps this provider's wording. The "Remember session" description gains a clarification (adopted ecosystem-wide) that toggling it off drops the stored long-lived tokens immediately.
+
 ## [3.8.1] - 2026-07-09
 
 ### Fixed

--- a/provider/strings.json
+++ b/provider/strings.json
@@ -42,18 +42,18 @@
       "label": "Saved presets (internal)"
     },
     "auth_device": {
-      "label": "Login with device code",
-      "description": "Open a verification URL on any device and enter the short code.",
-      "action_label": "Login with device code"
+      "label": "[%key:common::config_entries::auth_device::label%]",
+      "description": "[%key:common::config_entries::auth_device::description%]",
+      "action_label": "[%key:common::config_entries::auth_device::action_label%]"
     },
     "auth_qr": {
-      "label": "Login with QR code",
-      "description": "Opens a QR code page — scan it with the Yandex app on your phone.",
-      "action_label": "Login with QR code"
+      "label": "[%key:common::config_entries::auth_qr::label%]",
+      "description": "[%key:common::config_entries::auth_qr::description%]",
+      "action_label": "[%key:common::config_entries::auth_qr::action_label%]"
     },
     "remember_session": {
-      "label": "Remember session (auto-refresh token)",
-      "description": "When enabled, stores a long-lived session token to automatically refresh your music token when it expires. When disabled, you must re-authenticate manually when the token expires."
+      "label": "[%key:common::config_entries::remember_session::label%]",
+      "description": "[%key:common::config_entries::remember_session::description%]"
     },
     "clear_auth": {
       "label": "[%key:common::config_entries::clear_auth::label%]",
@@ -351,22 +351,22 @@
   "page": {
     "device_code": {
       "title": "Login to Yandex Music",
-      "step_copy": "Copy the code",
-      "hint_copy": "Tap the code to copy it",
-      "copied": "Copied ✓",
-      "copy_manual": "Automatic copy failed — select the code and copy it manually",
-      "step_open": "Open the Yandex page and enter the code",
-      "open_button": "Continue to Yandex",
-      "expires_label": "Code expires in",
-      "expired_title": "Code expired",
-      "expired_text": "The code is no longer valid. Return to Music Assistant and start the login again.",
-      "success_title": "Authorization successful",
-      "success_text": "You can close this window.",
-      "failed_title": "Authorization failed",
-      "failed_text": "Please return to Music Assistant and try again.",
-      "denied_text": "The login was denied. Return to Music Assistant and try again.",
-      "ended_title": "Session ended",
-      "ended_text": "This login session is no longer active. You can close this window."
+      "step_copy": "[%key:common::page::device_code::step_copy%]",
+      "hint_copy": "[%key:common::page::device_code::hint_copy%]",
+      "copied": "[%key:common::page::device_code::copied%]",
+      "copy_manual": "[%key:common::page::device_code::copy_manual%]",
+      "step_open": "[%key:common::page::device_code::step_open%]",
+      "open_button": "[%key:common::page::device_code::open_button%]",
+      "expires_label": "[%key:common::page::device_code::expires_label%]",
+      "expired_title": "[%key:common::page::device_code::expired_title%]",
+      "expired_text": "[%key:common::page::device_code::expired_text%]",
+      "success_title": "[%key:common::page::device_code::success_title%]",
+      "success_text": "[%key:common::page::device_code::success_text%]",
+      "failed_title": "[%key:common::page::device_code::failed_title%]",
+      "failed_text": "[%key:common::page::device_code::failed_text%]",
+      "denied_text": "[%key:common::page::device_code::denied_text%]",
+      "ended_title": "[%key:common::page::device_code::ended_title%]",
+      "ended_text": "[%key:common::page::device_code::ended_text%]"
     }
   }
 }


### PR DESCRIPTION
Rear-guard of the auth unification, companion to station#105: music-assistant/server#4690 shipped the shared auth strings in the common catalog, so local copies of `auth_device` / `auth_qr` / `remember_session` and `page.device_code.*` switch to `[%key:common::…%]` references (the `clear_auth` precedent). The page `title` and the three music-specific `auth_status_*` labels stay local.

One visible-text delta: `remember_session.description` now resolves to the ecosystem canon, which appends the "toggling this off … immediately drops the stored long-lived tokens" clarification this provider's copy lacked (behavior was already identical).

393 tests pass (strings parity suites tolerate references — keys remain authored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)