### PR TITLE
refactor: move private methods to the bottom of each class

### DIFF
--- a/provider/api_client.py
+++ b/provider/api_client.py
@@ -158,37 +158,6 @@ class YandexMusicClient:
             asyncio.Semaphore(RESTRICTIVE_GLOBAL_CONCURRENCY) if restrictive_rate_limits else None
         )
 
-    def _get_throttler(self, kind: str) -> Throttler:
-        return self._throttlers.get(kind, self._throttlers["default"])
-
-    def _get_endpoint_lock(self, endpoint: str) -> asyncio.Lock:
-        """Return (creating on demand) the per-endpoint serialization lock."""
-        lock = self._endpoint_locks.get(endpoint)
-        if lock is None:
-            lock = asyncio.Lock()
-            self._endpoint_locks[endpoint] = lock
-        return lock
-
-    @staticmethod
-    def _derive_endpoint(func: Callable[..., Any]) -> str | None:
-        """
-        Extract a stable endpoint key from a lambda's enclosing method.
-
-        Most ``_call_with_retry`` callers pass a lambda defined inside a
-        ``YandexMusicClient.<method>``; the lambda's ``__qualname__`` reads as
-        ``YandexMusicClient.<method>.<locals>.<lambda>``. We trim the
-        ``<locals>...`` suffix to get a per-method endpoint key, which
-        mirrors Yandex's per-URL-family edge limit. Returns ``None`` when
-        the qualname is missing or not in lambda form — in that case the
-        per-endpoint lock is skipped (no behaviour change for that call).
-        """
-        qn = getattr(func, "__qualname__", "")
-        if not qn:
-            return None
-        if ".<locals>." in qn:
-            return qn.split(".<locals>.", 1)[0]
-        return qn
-
     @property
     def user_id(self) -> int:
         """Return the user ID."""
@@ -224,368 +193,6 @@ class YandexMusicClient:
         self._client = None
         self._user_id = None
         self._connected_at = None
-
-    async def _ensure_connected(self) -> ClientAsync:
-        """Ensure the client is connected, attempting reconnect if needed."""
-        if self._client is not None:
-            return self._client
-        async with self._reconnect_lock:
-            # Re-check after acquiring lock — another task may have connected already
-            if self._client is not None:
-                return self._client  # type: ignore[unreachable]
-            LOGGER.info("Client disconnected, attempting to reconnect...")
-            try:
-                await self.connect()
-            except LoginFailed:
-                raise
-            except Exception as err:
-                raise ProviderUnavailableError("Client not connected and reconnect failed") from err
-        return cast("ClientAsync", self._client)
-
-    def _is_connection_error(self, err: Exception) -> bool:
-        """
-        Return True if the exception indicates a connection or server drop.
-
-        ``BadRequestError`` upstream extends ``NetworkError`` but represents a
-        terminal 4xx response (malformed query, geo-block) — retry-on-reconnect
-        would just reproduce the same failure and waste a connection cycle,
-        so it is explicitly excluded.
-        """
-        if isinstance(err, BadRequestError):
-            return False
-        if isinstance(err, NetworkError) and not self._is_rate_limit_error(err):
-            return True
-        msg = str(err).lower()
-        return "disconnect" in msg or "connection" in msg or "timeout" in msg
-
-    def _classify_429(self, err: Exception) -> Literal["captcha", "rate_limit", "other"]:
-        """
-        Classify a 429-ish error: smart-captcha edge block vs plain rate-limit.
-
-        Yandex returns an HTML smart-captcha page when its anti-bot edge layer
-        decides an endpoint family is too hot. That page is per-endpoint, not
-        per-IP, and warrants a longer cooldown than an ordinary 429.
-        """
-        if not isinstance(err, NetworkError):
-            return "other"
-        low = str(err).lower()
-        is_429 = "429" in low or "too many requests" in low or "rate limit" in low
-        if not is_429:
-            return "other"
-        # 429 payload dump for forensics: which markers actually matched and
-        # the first 2000 chars of the body. Captured at DEBUG so a single
-        # captcha trip in production can be reconstructed by flipping the
-        # provider log level — without flooding steady-state logs.
-        if LOGGER.isEnabledFor(logging.DEBUG):
-            matched_markers = [m for m in _CAPTCHA_MARKERS if m in low]
-            LOGGER.debug(
-                "429 classify forensics: markers_matched=%s body[:2000]=%r",
-                matched_markers,
-                str(err)[:2000],
-            )
-        return "captcha" if any(m in low for m in _CAPTCHA_MARKERS) else "rate_limit"
-
-    def _is_rate_limit_error(self, err: Exception) -> bool:
-        """Return True if the exception indicates a rate-limit response from Yandex."""
-        return self._classify_429(err) != "other"
-
-    @staticmethod
-    def _truncate_err_msg(err: Exception, limit: int = 200) -> str:
-        """Cap a NetworkError message so the captcha HTML body never lands in logs."""
-        msg = str(err)
-        return msg if len(msg) <= limit else msg[:limit] + "...[truncated]"
-
-    async def _reconnect(self) -> None:
-        """
-        Disconnect and connect again to recover from Server disconnected / connection errors.
-
-        Enforces a 30-second cooldown between reconnect attempts to avoid hammering Yandex
-        and triggering rate limiting. A lock ensures concurrent callers don't bypass the cooldown.
-        """
-        async with self._reconnect_lock:
-            now = time.monotonic()
-            if now - self._last_reconnect_at < 30.0:
-                raise ProviderUnavailableError("Reconnect cooldown active, skipping")
-            self._last_reconnect_at = now
-            await self.disconnect()
-            await self.connect()
-
-    def _check_block(self, kind: str) -> None:
-        """
-        Raise immediately if `kind` is under a captcha quarantine.
-
-        BYPASS_THROTTLER callers (stream URL refresh) must skip this check so a
-        currently playing track isn't dropped mid-stream when an unrelated
-        endpoint family trips smart-captcha.
-        """
-        deadline = self._block_until.get(kind, 0.0)
-        remaining = deadline - time.monotonic()
-        if remaining > 0:
-            raise ResourceTemporarilyUnavailable(
-                f"Yandex Music {kind} cooldown active",
-                backoff_time=int(remaining) + 1,
-            )
-
-    def _trigger_captcha_block(self, kind: str) -> int:
-        """
-        Quarantine the given throttler kind using the captcha-cooldown ladder.
-
-        Only called when _classify_429 == "captcha". Plain rate-limit responses
-        do NOT trigger this, since Yandex's smart-captcha bucket is per
-        endpoint family and we don't want to gate unrelated traffic.
-
-        :param kind: Throttler bucket name (e.g. "default", "metadata").
-        :return: The cooldown duration in seconds (rounded down to int).
-        """
-        now = time.monotonic()
-        strikes = self._captcha_strikes[kind]
-        cutoff = now - CAPTCHA_STRIKE_RETENTION_S
-        while strikes and strikes[0] < cutoff:
-            strikes.popleft()
-        strikes.append(now)
-        ladder = CAPTCHA_COOLDOWN_LADDER_S
-        idx = min(len(strikes), len(ladder)) - 1
-        cooldown = ladder[idx]
-        self._block_until[kind] = max(self._block_until.get(kind, 0.0), now + cooldown)
-        LOGGER.warning(
-            "Yandex Music %s captcha cooldown engaged: %.0fs (strike %d/%d in last %.0fs)",
-            kind,
-            cooldown,
-            len(strikes),
-            len(ladder),
-            CAPTCHA_STRIKE_RETENTION_S,
-        )
-        return int(cooldown)
-
-    def _maybe_handle_429(self, err: Exception, kind: str) -> ResourceTemporarilyUnavailable | None:
-        """
-        Classify a 429 error and build the user-facing exception.
-
-        Returns the prepared `ResourceTemporarilyUnavailable` to raise, or
-        ``None`` if the error isn't a 429 (caller should re-raise or fall
-        through to connection-error handling). Always truncates the message
-        so the smart-captcha HTML body never lands in logs.
-
-        Side effect: a captcha-classified result engages the per-kind block
-        deadline. Plain 429 leaves block deadlines untouched.
-        """
-        classified = self._classify_429(err)
-        if classified == "captcha":
-            backoff = self._trigger_captcha_block(kind)
-            return ResourceTemporarilyUnavailable(
-                f"Yandex Music captcha ({kind})",
-                backoff_time=backoff,
-            )
-        if classified == "rate_limit":
-            LOGGER.debug("Yandex Music plain 429 on kind=%s", kind)
-            return RateLimited(
-                "Yandex Music rate limit",
-                backoff_time=int(RATE_LIMIT_COOLDOWN_S),
-            )
-        return None
-
-    def _file_info_cache_get(self, key: tuple[str, str, str, str]) -> dict[str, Any] | None:
-        entry = self._file_info_cache.get(key)
-        if entry is None:
-            return None
-        expires_at, value = entry
-        if time.monotonic() >= expires_at:
-            self._file_info_cache.pop(key, None)
-            return None
-        self._file_info_cache.move_to_end(key)
-        return value
-
-    def _file_info_cache_put(self, key: tuple[str, str, str, str], value: dict[str, Any]) -> None:
-        self._file_info_cache[key] = (
-            time.monotonic() + FILE_INFO_CACHE_TTL_S,
-            value,
-        )
-        self._file_info_cache.move_to_end(key)
-        while len(self._file_info_cache) > FILE_INFO_CACHE_MAX:
-            self._file_info_cache.popitem(last=False)
-
-    def _file_info_cache_invalidate(self, track_id: str) -> None:
-        for k in [k for k in self._file_info_cache if k[0] == track_id]:
-            self._file_info_cache.pop(k, None)
-
-    async def _initial_sync_jitter(self, kind: str) -> None:
-        """
-        Sleep a small random delay during the first-sync window.
-
-        Smooths out the parallel metadata-refresh burst MA fires immediately
-        after a fresh install + auth, which is what triggers smart-captcha
-        in #146. After INITIAL_SYNC_WINDOW_S the helper is a no-op — no
-        steady-state overhead.
-
-        Only active for the `default` and `metadata` kinds. `file_info` is
-        on the streaming hot path (latency matters), and `rotor` has its
-        own bucket already tuned for its cadence.
-
-        :param kind: Throttler bucket name.
-        """
-        if kind not in ("default", "metadata"):
-            return
-        connected_at = self._connected_at
-        if connected_at is None:
-            return
-        if time.monotonic() - connected_at >= INITIAL_SYNC_WINDOW_S:
-            return
-        delay = random.uniform(0.0, INITIAL_SYNC_JITTER_S)
-        if delay > 0:
-            await asyncio.sleep(delay)
-
-    async def _call_with_retry(
-        self,
-        func: Callable[[ClientAsync], Awaitable[_T]],
-        *,
-        kind: str = "default",
-    ) -> _T:
-        """
-        Execute an async API call with throttling and one reconnect attempt on connection error.
-
-        Three layers of rate-control apply, outermost first:
-
-        * **Global concurrency cap** (restrictive mode only) — a
-          token-wide ``asyncio.Semaphore`` sized to ``RESTRICTIVE_GLOBAL_
-          CONCURRENCY``. Keeps total in-flight requests under Yandex's
-          per-token edge limit observed on datacenter / VPN IPs (~6).
-        * **Per-kind throttler** — a token bucket shared by all calls of a
-          given logical class (``default``, ``metadata``, ``file_info``,
-          ``rotor``). Caps sustained RPS per kind.
-        * **Per-endpoint lock** — derived from ``func.__qualname__`` so each
-          ``YandexMusicClient`` method gets its own ``asyncio.Lock``. Caps
-          concurrency to 1 per endpoint family — cheap defense-in-depth
-          against future ``asyncio.gather`` regressions; near-zero cost
-          when there's no contention.
-
-        :param func: Async callable that takes a ClientAsync and returns a result.
-        :param kind: Throttler bucket — one of the keys registered in
-            ``self._throttlers`` ("default", "metadata", "file_info",
-            "rotor"). Falls back to "default" if unknown.
-        :return: The result of the API call.
-        """
-        if self._global_concurrency is not None and not BYPASS_THROTTLER.get():
-            async with self._global_concurrency:
-                return await self._call_with_retry_inner(func, kind=kind)
-        return await self._call_with_retry_inner(func, kind=kind)
-
-    async def _call_with_retry_inner(
-        self,
-        func: Callable[[ClientAsync], Awaitable[_T]],
-        *,
-        kind: str,
-    ) -> _T:
-        """Per-kind throttler + per-endpoint lock layer of ``_call_with_retry``."""
-        # Per-request diagnostic — emits caller + kind so a DEBUG-level capture
-        # can reconstruct request density before any captcha trip. Stays at
-        # DEBUG so steady-state logs are clean.
-        if LOGGER.isEnabledFor(logging.DEBUG):
-            caller = getattr(func, "__qualname__", "?")
-            if ".<locals>." in caller:
-                caller = caller.split(".<locals>.")[0]
-            LOGGER.debug(
-                "req: kind=%s caller=%s bypass=%s",
-                kind,
-                caller,
-                BYPASS_THROTTLER.get(),
-            )
-        if not BYPASS_THROTTLER.get():
-            # Fast path: short-circuit before queueing if the kind is already
-            # blocked. Re-check after acquire() — another concurrent request
-            # may have engaged the cooldown while we were queued.
-            self._check_block(kind)
-            await self._initial_sync_jitter(kind)
-            await self._get_throttler(kind).acquire()
-            self._check_block(kind)
-        client = await self._ensure_connected()
-        endpoint = self._derive_endpoint(func)
-        try:
-            return await self._invoke_under_endpoint_lock(func, client, endpoint)
-        except Exception as err:
-            rate_limit_exc = self._maybe_handle_429(err, kind)
-            if rate_limit_exc is not None:
-                raise rate_limit_exc from NetworkError(self._truncate_err_msg(err))
-            if not self._is_connection_error(err):
-                raise
-            LOGGER.warning("Connection error, reconnecting and retrying: %s", err)
-            try:
-                await self._reconnect()
-            except Exception as recon_err:
-                raise ProviderUnavailableError("Reconnect failed") from recon_err
-            client = cast("ClientAsync", self._client)
-            # Re-check the block AND re-acquire a throttler token before the
-            # retry. Skipping ``acquire()`` here lets reconnect-retries
-            # bypass rate-limiting, doubling the effective request rate
-            # during connection flap — the conditions that already increase
-            # captcha-trip risk. BYPASS_THROTTLER paths skip this so an
-            # in-flight stream refresh can still attempt the retry.
-            if not BYPASS_THROTTLER.get():
-                self._check_block(kind)
-                await self._get_throttler(kind).acquire()
-                self._check_block(kind)
-            # Reconnect-retry must also go through 429 classification —
-            # otherwise a captcha on the retry attempt bypasses the cooldown
-            # logic and propagates the raw HTML body.
-            try:
-                return await self._invoke_under_endpoint_lock(func, client, endpoint)
-            except Exception as retry_err:
-                retry_exc = self._maybe_handle_429(retry_err, kind)
-                if retry_exc is not None:
-                    raise retry_exc from NetworkError(self._truncate_err_msg(retry_err))
-                raise
-
-    async def _invoke_under_endpoint_lock(
-        self,
-        func: Callable[[ClientAsync], Awaitable[_T]],
-        client: ClientAsync,
-        endpoint: str | None,
-    ) -> _T:
-        """Run ``func(client)`` serialised by the per-endpoint lock when set."""
-        if endpoint is None:
-            return await func(client)
-        async with self._get_endpoint_lock(endpoint):
-            return await func(client)
-
-    async def _call_no_retry(
-        self,
-        func: Callable[[ClientAsync], Awaitable[_T]],
-        *,
-        kind: str = "default",
-    ) -> _T:
-        """
-        Execute an async API call without reconnect retry on call failure.
-
-        Used for fire-and-forget calls (e.g. rotor feedback) where a failed request
-        should be silently dropped rather than triggering a reconnect cycle that
-        could cause rate limiting. Note: _ensure_connected() is still called to
-        establish the initial connection if needed; only the reconnect-on-error
-        path is skipped.
-
-        :param func: Async callable that takes a ClientAsync and returns a result.
-        :param kind: Throttler bucket — one of the keys registered in
-            ``self._throttlers`` ("default", "metadata", "file_info",
-            "rotor"). Falls back to "default" if unknown.
-        :return: The result of the API call.
-        """
-        if not BYPASS_THROTTLER.get():
-            # Same dual check as _call_with_retry — see comment there.
-            self._check_block(kind)
-            await self._initial_sync_jitter(kind)
-            await self._get_throttler(kind).acquire()
-            self._check_block(kind)
-        client = await self._ensure_connected()
-        try:
-            return await func(client)
-        except Exception as err:
-            # Even on the fire-and-forget path we want to classify 429s: a
-            # captcha hit on rotor feedback must still quarantine the rotor
-            # kind so the rest of the provider stops poking Yandex's edge
-            # while it's hot. Truncation also prevents callers' broad
-            # `except NetworkError` from logging multi-KB HTML payloads.
-            rate_limit_exc = self._maybe_handle_429(err, kind)
-            if rate_limit_exc is not None:
-                raise rate_limit_exc from NetworkError(self._truncate_err_msg(err))
-            raise
 
     # Rotor (radio station) methods
 
@@ -737,81 +344,6 @@ class YandexMusicClient:
             )
             return False
 
-    # Rotor session API (new session-based endpoints)
-    #
-    # Yandex's newer rotor API models a wave as a long-lived session:
-    #   POST /rotor/session/new                     → {radioSessionId, sequence, batchId}
-    #   POST /rotor/session/{sessionId}/tracks      → {sequence, batchId}
-    #   POST /rotor/session/{sessionId}/feedback    → {result: "ok"}
-    # All feedback events carry the same sessionId, so we no longer need to
-    # thread per-batch batch_ids through call sites the way the stations-based
-    # API forced us to.
-
-    async def _rotor_session_request(
-        self, path: str, body: dict[str, Any], *, with_retry: bool = True
-    ) -> dict[str, Any] | None:
-        """
-        POST a JSON body to /rotor/session/{path} and return parsed result.
-
-        Reuses the MarshalX ClientAsync internal request object so we inherit
-        its auth headers and parsing. `json=` is forwarded to `aiohttp.request`
-        by MarshalX's `**kwargs` passthrough.
-
-        :param path: Path suffix after /rotor/session/ (e.g. "new",
-            "{session_id}/tracks", "{session_id}/feedback").
-        :param body: JSON body to send.
-        :param with_retry: When True (default), uses the same reconnect-on-
-            transient-connection-error path as normal data fetches —
-            appropriate for ``new`` and ``tracks`` which sit on the
-            user-facing browse/play path. Set to False for ``feedback``,
-            where a dropped request should be silently lost rather than
-            hammered against a potentially rate-limiting server.
-        :return: Parsed result dict, or None on failure.
-        """
-
-        async def _do(c: ClientAsync) -> dict[str, Any] | None:
-            base = getattr(c, "base_url", "https://api.music.yandex.net")
-            url = f"{base}/rotor/session/{path}"
-            LOGGER.debug("Rotor session POST %s body_keys=%s", path, list(body.keys()))
-            try:
-                result = await c._request.post(url, json=body)
-            except NetworkError as err:
-                # Let the outer retry wrapper see transient drops. On the
-                # no-retry path swallow ordinary network blips silently, but
-                # 429/captcha errors MUST propagate so _call_no_retry can
-                # engage the rotor cooldown — otherwise feedback keeps
-                # hammering Yandex during an active edge ban.
-                if with_retry or self._is_rate_limit_error(err):
-                    raise
-                LOGGER.debug("Rotor session POST %s: network error (no retry)", path)
-                return None
-            except BadRequestError as err:
-                # 4xx is terminal — server rejected the body; retry would only
-                # reproduce the same failure.
-                LOGGER.warning("Rotor session POST %s failed: %s", path, err)
-                return None
-            if isinstance(result, dict):
-                LOGGER.debug("Rotor session POST %s → result keys=%s", path, list(result.keys()))
-                return result
-            LOGGER.debug("Rotor session POST %s → non-dict result: %r", path, result)
-            return None
-
-        runner = self._call_with_retry if with_retry else self._call_no_retry
-        try:
-            return await runner(_do, kind="rotor")
-        except UnauthorizedError as err:
-            # Expired/invalidated token. Surface as LoginFailed so MA prompts
-            # for re-auth instead of the raw yandex_music exception bubbling
-            # through browse / play and crashing the caller.
-            LOGGER.warning("Rotor session POST %s: token no longer valid", path)
-            raise LoginFailed("Invalid Yandex Music token") from err
-        except ResourceTemporarilyUnavailable as err:
-            LOGGER.warning("Rotor session POST %s rate-limited: %s", path, err)
-            return None
-        except (NetworkError, ProviderUnavailableError) as err:
-            LOGGER.warning("Rotor session POST %s failed: %s", path, self._truncate_err_msg(err))
-            return None
-
     async def rotor_session_new(
         self,
         station_id: str,
@@ -925,36 +457,6 @@ class YandexMusicClient:
         )
         result = await self._rotor_session_request(f"{session_id}/feedback", body, with_retry=False)
         return result is not None
-
-    async def _hydrate_session_tracks(self, sequence: list[dict[str, Any]]) -> list[YandexTrack]:
-        """
-        Extract track IDs from a rotor session sequence and hydrate via get_tracks.
-
-        The session endpoints return tracks inline when includeTracksInResponse
-        is true, but full track objects (with download info, covers, etc.) are
-        fetched separately so parsed Track objects have the same shape as in
-        the rest of the provider.
-
-        :param sequence: List of sequence items from a rotor session response.
-        :return: List of full track objects in the same order as `sequence`.
-        """
-        track_ids: list[str] = []
-        for seq in sequence:
-            tr = seq.get("track") if isinstance(seq, dict) else None
-            tid = None
-            if isinstance(tr, dict):
-                tid = tr.get("id") or tr.get("track_id")
-            if tid is not None:
-                track_ids.append(str(tid))
-        if not track_ids:
-            return []
-        try:
-            full_tracks = await self.get_tracks(track_ids)
-        except ResourceTemporarilyUnavailable as err:
-            LOGGER.warning("Rotor session track hydration failed: %s", err)
-            return []
-        order_map = {str(t.id): t for t in full_tracks if hasattr(t, "id") and t.id}
-        return [order_map[tid] for tid in track_ids if tid in order_map]
 
     async def play_audio(
         self,
@@ -1800,40 +1302,6 @@ class YandexMusicClient:
         """
         return await self._get_landing_waves("waves")
 
-    async def _get_landing_waves(self, block: str) -> list[dict[str, Any]] | None:
-        """
-        Fetch wave categories from a /landing-blocks/<block> endpoint.
-
-        Note: Response keys are auto-converted from camelCase to snake_case
-        by the yandex-music library's JSON parser.
-
-        :param block: Block name, e.g. 'waves' or 'mixes-waves'.
-        :return: List of wave category dicts, or None on error.
-        """
-
-        async def _get(c: ClientAsync) -> dict[str, Any]:
-            # ``base_url`` is not part of the public ``ClientAsync`` contract;
-            # mirror ``_rotor_session_request`` and fall back defensively so a
-            # library rename does not crash this endpoint with AttributeError.
-            base = getattr(c, "base_url", "https://api.music.yandex.net")
-            url = f"{base}/landing-blocks/{block}"
-            return await c._request.get(url)  # type: ignore[no-any-return]
-
-        try:
-            result = await self._call_with_retry(_get)
-            if result and isinstance(result, dict):
-                waves = result.get("waves", [])
-                LOGGER.debug(
-                    "landing-blocks/%s returned %d categories",
-                    block,
-                    len(waves) if isinstance(waves, list) else -1,
-                )
-                return waves if isinstance(waves, list) else []
-            return None
-        except (BadRequestError, NetworkError, ProviderUnavailableError) as err:
-            LOGGER.debug("Error fetching landing-blocks/%s: %s", block, err)
-            return None
-
     async def get_wave_stations(
         self, language: str | None = None
     ) -> list[tuple[str, str, str, str | None]]:
@@ -2018,3 +1486,535 @@ class YandexMusicClient:
         except (BadRequestError, NetworkError, ProviderUnavailableError) as err:
             LOGGER.error("Error unliking artist %s: %s", artist_id, err)
             return False
+
+    def _get_throttler(self, kind: str) -> Throttler:
+        return self._throttlers.get(kind, self._throttlers["default"])
+
+    def _get_endpoint_lock(self, endpoint: str) -> asyncio.Lock:
+        """Return (creating on demand) the per-endpoint serialization lock."""
+        lock = self._endpoint_locks.get(endpoint)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._endpoint_locks[endpoint] = lock
+        return lock
+
+    @staticmethod
+    def _derive_endpoint(func: Callable[..., Any]) -> str | None:
+        """
+        Extract a stable endpoint key from a lambda's enclosing method.
+
+        Most ``_call_with_retry`` callers pass a lambda defined inside a
+        ``YandexMusicClient.<method>``; the lambda's ``__qualname__`` reads as
+        ``YandexMusicClient.<method>.<locals>.<lambda>``. We trim the
+        ``<locals>...`` suffix to get a per-method endpoint key, which
+        mirrors Yandex's per-URL-family edge limit. Returns ``None`` when
+        the qualname is missing or not in lambda form — in that case the
+        per-endpoint lock is skipped (no behaviour change for that call).
+        """
+        qn = getattr(func, "__qualname__", "")
+        if not qn:
+            return None
+        if ".<locals>." in qn:
+            return qn.split(".<locals>.", 1)[0]
+        return qn
+
+    async def _ensure_connected(self) -> ClientAsync:
+        """Ensure the client is connected, attempting reconnect if needed."""
+        if self._client is not None:
+            return self._client
+        async with self._reconnect_lock:
+            # Re-check after acquiring lock — another task may have connected already
+            if self._client is not None:
+                return self._client  # type: ignore[unreachable]
+            LOGGER.info("Client disconnected, attempting to reconnect...")
+            try:
+                await self.connect()
+            except LoginFailed:
+                raise
+            except Exception as err:
+                raise ProviderUnavailableError("Client not connected and reconnect failed") from err
+        return cast("ClientAsync", self._client)
+
+    def _is_connection_error(self, err: Exception) -> bool:
+        """
+        Return True if the exception indicates a connection or server drop.
+
+        ``BadRequestError`` upstream extends ``NetworkError`` but represents a
+        terminal 4xx response (malformed query, geo-block) — retry-on-reconnect
+        would just reproduce the same failure and waste a connection cycle,
+        so it is explicitly excluded.
+        """
+        if isinstance(err, BadRequestError):
+            return False
+        if isinstance(err, NetworkError) and not self._is_rate_limit_error(err):
+            return True
+        msg = str(err).lower()
+        return "disconnect" in msg or "connection" in msg or "timeout" in msg
+
+    def _classify_429(self, err: Exception) -> Literal["captcha", "rate_limit", "other"]:
+        """
+        Classify a 429-ish error: smart-captcha edge block vs plain rate-limit.
+
+        Yandex returns an HTML smart-captcha page when its anti-bot edge layer
+        decides an endpoint family is too hot. That page is per-endpoint, not
+        per-IP, and warrants a longer cooldown than an ordinary 429.
+        """
+        if not isinstance(err, NetworkError):
+            return "other"
+        low = str(err).lower()
+        is_429 = "429" in low or "too many requests" in low or "rate limit" in low
+        if not is_429:
+            return "other"
+        # 429 payload dump for forensics: which markers actually matched and
+        # the first 2000 chars of the body. Captured at DEBUG so a single
+        # captcha trip in production can be reconstructed by flipping the
+        # provider log level — without flooding steady-state logs.
+        if LOGGER.isEnabledFor(logging.DEBUG):
+            matched_markers = [m for m in _CAPTCHA_MARKERS if m in low]
+            LOGGER.debug(
+                "429 classify forensics: markers_matched=%s body[:2000]=%r",
+                matched_markers,
+                str(err)[:2000],
+            )
+        return "captcha" if any(m in low for m in _CAPTCHA_MARKERS) else "rate_limit"
+
+    def _is_rate_limit_error(self, err: Exception) -> bool:
+        """Return True if the exception indicates a rate-limit response from Yandex."""
+        return self._classify_429(err) != "other"
+
+    @staticmethod
+    def _truncate_err_msg(err: Exception, limit: int = 200) -> str:
+        """Cap a NetworkError message so the captcha HTML body never lands in logs."""
+        msg = str(err)
+        return msg if len(msg) <= limit else msg[:limit] + "...[truncated]"
+
+    async def _reconnect(self) -> None:
+        """
+        Disconnect and connect again to recover from Server disconnected / connection errors.
+
+        Enforces a 30-second cooldown between reconnect attempts to avoid hammering Yandex
+        and triggering rate limiting. A lock ensures concurrent callers don't bypass the cooldown.
+        """
+        async with self._reconnect_lock:
+            now = time.monotonic()
+            if now - self._last_reconnect_at < 30.0:
+                raise ProviderUnavailableError("Reconnect cooldown active, skipping")
+            self._last_reconnect_at = now
+            await self.disconnect()
+            await self.connect()
+
+    def _check_block(self, kind: str) -> None:
+        """
+        Raise immediately if `kind` is under a captcha quarantine.
+
+        BYPASS_THROTTLER callers (stream URL refresh) must skip this check so a
+        currently playing track isn't dropped mid-stream when an unrelated
+        endpoint family trips smart-captcha.
+        """
+        deadline = self._block_until.get(kind, 0.0)
+        remaining = deadline - time.monotonic()
+        if remaining > 0:
+            raise ResourceTemporarilyUnavailable(
+                f"Yandex Music {kind} cooldown active",
+                backoff_time=int(remaining) + 1,
+            )
+
+    def _trigger_captcha_block(self, kind: str) -> int:
+        """
+        Quarantine the given throttler kind using the captcha-cooldown ladder.
+
+        Only called when _classify_429 == "captcha". Plain rate-limit responses
+        do NOT trigger this, since Yandex's smart-captcha bucket is per
+        endpoint family and we don't want to gate unrelated traffic.
+
+        :param kind: Throttler bucket name (e.g. "default", "metadata").
+        :return: The cooldown duration in seconds (rounded down to int).
+        """
+        now = time.monotonic()
+        strikes = self._captcha_strikes[kind]
+        cutoff = now - CAPTCHA_STRIKE_RETENTION_S
+        while strikes and strikes[0] < cutoff:
+            strikes.popleft()
+        strikes.append(now)
+        ladder = CAPTCHA_COOLDOWN_LADDER_S
+        idx = min(len(strikes), len(ladder)) - 1
+        cooldown = ladder[idx]
+        self._block_until[kind] = max(self._block_until.get(kind, 0.0), now + cooldown)
+        LOGGER.warning(
+            "Yandex Music %s captcha cooldown engaged: %.0fs (strike %d/%d in last %.0fs)",
+            kind,
+            cooldown,
+            len(strikes),
+            len(ladder),
+            CAPTCHA_STRIKE_RETENTION_S,
+        )
+        return int(cooldown)
+
+    def _maybe_handle_429(self, err: Exception, kind: str) -> ResourceTemporarilyUnavailable | None:
+        """
+        Classify a 429 error and build the user-facing exception.
+
+        Returns the prepared `ResourceTemporarilyUnavailable` to raise, or
+        ``None`` if the error isn't a 429 (caller should re-raise or fall
+        through to connection-error handling). Always truncates the message
+        so the smart-captcha HTML body never lands in logs.
+
+        Side effect: a captcha-classified result engages the per-kind block
+        deadline. Plain 429 leaves block deadlines untouched.
+        """
+        classified = self._classify_429(err)
+        if classified == "captcha":
+            backoff = self._trigger_captcha_block(kind)
+            return ResourceTemporarilyUnavailable(
+                f"Yandex Music captcha ({kind})",
+                backoff_time=backoff,
+            )
+        if classified == "rate_limit":
+            LOGGER.debug("Yandex Music plain 429 on kind=%s", kind)
+            return RateLimited(
+                "Yandex Music rate limit",
+                backoff_time=int(RATE_LIMIT_COOLDOWN_S),
+            )
+        return None
+
+    def _file_info_cache_get(self, key: tuple[str, str, str, str]) -> dict[str, Any] | None:
+        entry = self._file_info_cache.get(key)
+        if entry is None:
+            return None
+        expires_at, value = entry
+        if time.monotonic() >= expires_at:
+            self._file_info_cache.pop(key, None)
+            return None
+        self._file_info_cache.move_to_end(key)
+        return value
+
+    def _file_info_cache_put(self, key: tuple[str, str, str, str], value: dict[str, Any]) -> None:
+        self._file_info_cache[key] = (
+            time.monotonic() + FILE_INFO_CACHE_TTL_S,
+            value,
+        )
+        self._file_info_cache.move_to_end(key)
+        while len(self._file_info_cache) > FILE_INFO_CACHE_MAX:
+            self._file_info_cache.popitem(last=False)
+
+    def _file_info_cache_invalidate(self, track_id: str) -> None:
+        for k in [k for k in self._file_info_cache if k[0] == track_id]:
+            self._file_info_cache.pop(k, None)
+
+    async def _initial_sync_jitter(self, kind: str) -> None:
+        """
+        Sleep a small random delay during the first-sync window.
+
+        Smooths out the parallel metadata-refresh burst MA fires immediately
+        after a fresh install + auth, which is what triggers smart-captcha
+        in #146. After INITIAL_SYNC_WINDOW_S the helper is a no-op — no
+        steady-state overhead.
+
+        Only active for the `default` and `metadata` kinds. `file_info` is
+        on the streaming hot path (latency matters), and `rotor` has its
+        own bucket already tuned for its cadence.
+
+        :param kind: Throttler bucket name.
+        """
+        if kind not in ("default", "metadata"):
+            return
+        connected_at = self._connected_at
+        if connected_at is None:
+            return
+        if time.monotonic() - connected_at >= INITIAL_SYNC_WINDOW_S:
+            return
+        delay = random.uniform(0.0, INITIAL_SYNC_JITTER_S)
+        if delay > 0:
+            await asyncio.sleep(delay)
+
+    async def _call_with_retry(
+        self,
+        func: Callable[[ClientAsync], Awaitable[_T]],
+        *,
+        kind: str = "default",
+    ) -> _T:
+        """
+        Execute an async API call with throttling and one reconnect attempt on connection error.
+
+        Three layers of rate-control apply, outermost first:
+
+        * **Global concurrency cap** (restrictive mode only) — a
+          token-wide ``asyncio.Semaphore`` sized to ``RESTRICTIVE_GLOBAL_
+          CONCURRENCY``. Keeps total in-flight requests under Yandex's
+          per-token edge limit observed on datacenter / VPN IPs (~6).
+        * **Per-kind throttler** — a token bucket shared by all calls of a
+          given logical class (``default``, ``metadata``, ``file_info``,
+          ``rotor``). Caps sustained RPS per kind.
+        * **Per-endpoint lock** — derived from ``func.__qualname__`` so each
+          ``YandexMusicClient`` method gets its own ``asyncio.Lock``. Caps
+          concurrency to 1 per endpoint family — cheap defense-in-depth
+          against future ``asyncio.gather`` regressions; near-zero cost
+          when there's no contention.
+
+        :param func: Async callable that takes a ClientAsync and returns a result.
+        :param kind: Throttler bucket — one of the keys registered in
+            ``self._throttlers`` ("default", "metadata", "file_info",
+            "rotor"). Falls back to "default" if unknown.
+        :return: The result of the API call.
+        """
+        if self._global_concurrency is not None and not BYPASS_THROTTLER.get():
+            async with self._global_concurrency:
+                return await self._call_with_retry_inner(func, kind=kind)
+        return await self._call_with_retry_inner(func, kind=kind)
+
+    async def _call_with_retry_inner(
+        self,
+        func: Callable[[ClientAsync], Awaitable[_T]],
+        *,
+        kind: str,
+    ) -> _T:
+        """Per-kind throttler + per-endpoint lock layer of ``_call_with_retry``."""
+        # Per-request diagnostic — emits caller + kind so a DEBUG-level capture
+        # can reconstruct request density before any captcha trip. Stays at
+        # DEBUG so steady-state logs are clean.
+        if LOGGER.isEnabledFor(logging.DEBUG):
+            caller = getattr(func, "__qualname__", "?")
+            if ".<locals>." in caller:
+                caller = caller.split(".<locals>.")[0]
+            LOGGER.debug(
+                "req: kind=%s caller=%s bypass=%s",
+                kind,
+                caller,
+                BYPASS_THROTTLER.get(),
+            )
+        if not BYPASS_THROTTLER.get():
+            # Fast path: short-circuit before queueing if the kind is already
+            # blocked. Re-check after acquire() — another concurrent request
+            # may have engaged the cooldown while we were queued.
+            self._check_block(kind)
+            await self._initial_sync_jitter(kind)
+            await self._get_throttler(kind).acquire()
+            self._check_block(kind)
+        client = await self._ensure_connected()
+        endpoint = self._derive_endpoint(func)
+        try:
+            return await self._invoke_under_endpoint_lock(func, client, endpoint)
+        except Exception as err:
+            rate_limit_exc = self._maybe_handle_429(err, kind)
+            if rate_limit_exc is not None:
+                raise rate_limit_exc from NetworkError(self._truncate_err_msg(err))
+            if not self._is_connection_error(err):
+                raise
+            LOGGER.warning("Connection error, reconnecting and retrying: %s", err)
+            try:
+                await self._reconnect()
+            except Exception as recon_err:
+                raise ProviderUnavailableError("Reconnect failed") from recon_err
+            client = cast("ClientAsync", self._client)
+            # Re-check the block AND re-acquire a throttler token before the
+            # retry. Skipping ``acquire()`` here lets reconnect-retries
+            # bypass rate-limiting, doubling the effective request rate
+            # during connection flap — the conditions that already increase
+            # captcha-trip risk. BYPASS_THROTTLER paths skip this so an
+            # in-flight stream refresh can still attempt the retry.
+            if not BYPASS_THROTTLER.get():
+                self._check_block(kind)
+                await self._get_throttler(kind).acquire()
+                self._check_block(kind)
+            # Reconnect-retry must also go through 429 classification —
+            # otherwise a captcha on the retry attempt bypasses the cooldown
+            # logic and propagates the raw HTML body.
+            try:
+                return await self._invoke_under_endpoint_lock(func, client, endpoint)
+            except Exception as retry_err:
+                retry_exc = self._maybe_handle_429(retry_err, kind)
+                if retry_exc is not None:
+                    raise retry_exc from NetworkError(self._truncate_err_msg(retry_err))
+                raise
+
+    async def _invoke_under_endpoint_lock(
+        self,
+        func: Callable[[ClientAsync], Awaitable[_T]],
+        client: ClientAsync,
+        endpoint: str | None,
+    ) -> _T:
+        """Run ``func(client)`` serialised by the per-endpoint lock when set."""
+        if endpoint is None:
+            return await func(client)
+        async with self._get_endpoint_lock(endpoint):
+            return await func(client)
+
+    async def _call_no_retry(
+        self,
+        func: Callable[[ClientAsync], Awaitable[_T]],
+        *,
+        kind: str = "default",
+    ) -> _T:
+        """
+        Execute an async API call without reconnect retry on call failure.
+
+        Used for fire-and-forget calls (e.g. rotor feedback) where a failed request
+        should be silently dropped rather than triggering a reconnect cycle that
+        could cause rate limiting. Note: _ensure_connected() is still called to
+        establish the initial connection if needed; only the reconnect-on-error
+        path is skipped.
+
+        :param func: Async callable that takes a ClientAsync and returns a result.
+        :param kind: Throttler bucket — one of the keys registered in
+            ``self._throttlers`` ("default", "metadata", "file_info",
+            "rotor"). Falls back to "default" if unknown.
+        :return: The result of the API call.
+        """
+        if not BYPASS_THROTTLER.get():
+            # Same dual check as _call_with_retry — see comment there.
+            self._check_block(kind)
+            await self._initial_sync_jitter(kind)
+            await self._get_throttler(kind).acquire()
+            self._check_block(kind)
+        client = await self._ensure_connected()
+        try:
+            return await func(client)
+        except Exception as err:
+            # Even on the fire-and-forget path we want to classify 429s: a
+            # captcha hit on rotor feedback must still quarantine the rotor
+            # kind so the rest of the provider stops poking Yandex's edge
+            # while it's hot. Truncation also prevents callers' broad
+            # `except NetworkError` from logging multi-KB HTML payloads.
+            rate_limit_exc = self._maybe_handle_429(err, kind)
+            if rate_limit_exc is not None:
+                raise rate_limit_exc from NetworkError(self._truncate_err_msg(err))
+            raise
+
+    # Rotor session API (new session-based endpoints)
+    #
+    # Yandex's newer rotor API models a wave as a long-lived session:
+    #   POST /rotor/session/new                     → {radioSessionId, sequence, batchId}
+    #   POST /rotor/session/{sessionId}/tracks      → {sequence, batchId}
+    #   POST /rotor/session/{sessionId}/feedback    → {result: "ok"}
+    # All feedback events carry the same sessionId, so we no longer need to
+    # thread per-batch batch_ids through call sites the way the stations-based
+    # API forced us to.
+
+    async def _rotor_session_request(
+        self, path: str, body: dict[str, Any], *, with_retry: bool = True
+    ) -> dict[str, Any] | None:
+        """
+        POST a JSON body to /rotor/session/{path} and return parsed result.
+
+        Reuses the MarshalX ClientAsync internal request object so we inherit
+        its auth headers and parsing. `json=` is forwarded to `aiohttp.request`
+        by MarshalX's `**kwargs` passthrough.
+
+        :param path: Path suffix after /rotor/session/ (e.g. "new",
+            "{session_id}/tracks", "{session_id}/feedback").
+        :param body: JSON body to send.
+        :param with_retry: When True (default), uses the same reconnect-on-
+            transient-connection-error path as normal data fetches —
+            appropriate for ``new`` and ``tracks`` which sit on the
+            user-facing browse/play path. Set to False for ``feedback``,
+            where a dropped request should be silently lost rather than
+            hammered against a potentially rate-limiting server.
+        :return: Parsed result dict, or None on failure.
+        """
+
+        async def _do(c: ClientAsync) -> dict[str, Any] | None:
+            base = getattr(c, "base_url", "https://api.music.yandex.net")
+            url = f"{base}/rotor/session/{path}"
+            LOGGER.debug("Rotor session POST %s body_keys=%s", path, list(body.keys()))
+            try:
+                result = await c._request.post(url, json=body)
+            except NetworkError as err:
+                # Let the outer retry wrapper see transient drops. On the
+                # no-retry path swallow ordinary network blips silently, but
+                # 429/captcha errors MUST propagate so _call_no_retry can
+                # engage the rotor cooldown — otherwise feedback keeps
+                # hammering Yandex during an active edge ban.
+                if with_retry or self._is_rate_limit_error(err):
+                    raise
+                LOGGER.debug("Rotor session POST %s: network error (no retry)", path)
+                return None
+            except BadRequestError as err:
+                # 4xx is terminal — server rejected the body; retry would only
+                # reproduce the same failure.
+                LOGGER.warning("Rotor session POST %s failed: %s", path, err)
+                return None
+            if isinstance(result, dict):
+                LOGGER.debug("Rotor session POST %s → result keys=%s", path, list(result.keys()))
+                return result
+            LOGGER.debug("Rotor session POST %s → non-dict result: %r", path, result)
+            return None
+
+        runner = self._call_with_retry if with_retry else self._call_no_retry
+        try:
+            return await runner(_do, kind="rotor")
+        except UnauthorizedError as err:
+            # Expired/invalidated token. Surface as LoginFailed so MA prompts
+            # for re-auth instead of the raw yandex_music exception bubbling
+            # through browse / play and crashing the caller.
+            LOGGER.warning("Rotor session POST %s: token no longer valid", path)
+            raise LoginFailed("Invalid Yandex Music token") from err
+        except ResourceTemporarilyUnavailable as err:
+            LOGGER.warning("Rotor session POST %s rate-limited: %s", path, err)
+            return None
+        except (NetworkError, ProviderUnavailableError) as err:
+            LOGGER.warning("Rotor session POST %s failed: %s", path, self._truncate_err_msg(err))
+            return None
+
+    async def _hydrate_session_tracks(self, sequence: list[dict[str, Any]]) -> list[YandexTrack]:
+        """
+        Extract track IDs from a rotor session sequence and hydrate via get_tracks.
+
+        The session endpoints return tracks inline when includeTracksInResponse
+        is true, but full track objects (with download info, covers, etc.) are
+        fetched separately so parsed Track objects have the same shape as in
+        the rest of the provider.
+
+        :param sequence: List of sequence items from a rotor session response.
+        :return: List of full track objects in the same order as `sequence`.
+        """
+        track_ids: list[str] = []
+        for seq in sequence:
+            tr = seq.get("track") if isinstance(seq, dict) else None
+            tid = None
+            if isinstance(tr, dict):
+                tid = tr.get("id") or tr.get("track_id")
+            if tid is not None:
+                track_ids.append(str(tid))
+        if not track_ids:
+            return []
+        try:
+            full_tracks = await self.get_tracks(track_ids)
+        except ResourceTemporarilyUnavailable as err:
+            LOGGER.warning("Rotor session track hydration failed: %s", err)
+            return []
+        order_map = {str(t.id): t for t in full_tracks if hasattr(t, "id") and t.id}
+        return [order_map[tid] for tid in track_ids if tid in order_map]
+
+    async def _get_landing_waves(self, block: str) -> list[dict[str, Any]] | None:
+        """
+        Fetch wave categories from a /landing-blocks/<block> endpoint.
+
+        Note: Response keys are auto-converted from camelCase to snake_case
+        by the yandex-music library's JSON parser.
+
+        :param block: Block name, e.g. 'waves' or 'mixes-waves'.
+        :return: List of wave category dicts, or None on error.
+        """
+
+        async def _get(c: ClientAsync) -> dict[str, Any]:
+            # ``base_url`` is not part of the public ``ClientAsync`` contract;
+            # mirror ``_rotor_session_request`` and fall back defensively so a
+            # library rename does not crash this endpoint with AttributeError.
+            base = getattr(c, "base_url", "https://api.music.yandex.net")
+            url = f"{base}/landing-blocks/{block}"
+            return await c._request.get(url)  # type: ignore[no-any-return]
+
+        try:
+            result = await self._call_with_retry(_get)
+            if result and isinstance(result, dict):
+                waves = result.get("waves", [])
+                LOGGER.debug(
+                    "landing-blocks/%s returned %d categories",
+                    block,
+                    len(waves) if isinstance(waves, list) else -1,
+                )
+                return waves if isinstance(waves, list) else []
+            return None
+        except (BadRequestError, NetworkError, ProviderUnavailableError) as err:
+            LOGGER.debug("Error fetching landing-blocks/%s: %s", block, err)
+            return None

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -247,78 +247,6 @@ class YandexMusicProvider(MusicProvider):
             raise ProviderUnavailableError("Provider not initialized")
         return self._streaming
 
-    def _media_label(self, group: str, key: str, fallback: str) -> tuple[str, str | None]:
-        """
-        Resolve a media label to its English ``name`` and ``translation_key``.
-
-        The English source string lives in the provider's ``strings.json`` (the single source
-        of truth) and is localized for the connection locale at serialization via the returned
-        key. An unauthored key — e.g. a tag discovered from Yandex's landing API — returns
-        ``(fallback, None)`` so its already-localized name is kept verbatim.
-
-        :param group: Media translation group (``folder``, ``recommendations`` or ``playlist``).
-        :param key: Authoring key within the group; also the item's ``translation_key``.
-        :param fallback: English name to use when no string is authored for *key*.
-        """
-        authored = self.mass.translations.get_translation(
-            f"provider.{self.domain}.media.{group}.{key}.name"
-        )
-        if authored is None:
-            return fallback, None
-        return authored, key
-
-    async def _reauth_via_refresh_token(
-        self, x_token: str, refresh_token: str, base_url: str, original_err: Exception
-    ) -> None:
-        """
-        Silently re-issue full credentials when x_token refresh fails.
-
-        Device-flow accounts have a refresh_token that can mint a new
-        x_token + refresh_token + music_token without any user interaction.
-        Persists the rotated triple and connects the client. Any failure
-        here is terminal — clears all credentials and forces re-auth.
-        """
-        try:
-            new_creds = await refresh_credentials_via_passport(
-                SecretStr(x_token), SecretStr(refresh_token)
-            )
-        except ResourceTemporarilyUnavailable as err2:
-            # Transient Passport failure — keep creds, let MA retry later
-            self.logger.warning(
-                "Credential refresh temporarily unavailable: %s", type(err2).__name__
-            )
-            raise ProviderUnavailableError(
-                "Unable to refresh credentials right now. Please try again later."
-            ) from err2
-        except LoginFailed as err2:
-            self.logger.warning("Session and refresh tokens are both expired")
-            self._update_config_value(CONF_TOKEN, None, encrypted=True)
-            self._update_config_value(CONF_X_TOKEN, None, encrypted=True)
-            self._update_config_value(CONF_REFRESH_TOKEN, None, encrypted=True)
-            raise LoginFailed("Session expired. Please re-authenticate.") from err2
-
-        new_music_token = new_creds.music_token
-        new_refresh_token = new_creds.refresh_token
-        if new_music_token is None or new_refresh_token is None:
-            self._update_config_value(CONF_TOKEN, None, encrypted=True)
-            self._update_config_value(CONF_X_TOKEN, None, encrypted=True)
-            self._update_config_value(CONF_REFRESH_TOKEN, None, encrypted=True)
-            raise LoginFailed(
-                "Credential refresh returned an incomplete response."
-            ) from original_err
-
-        self._update_config_value(CONF_TOKEN, new_music_token.get_secret(), encrypted=True)
-        self._update_config_value(CONF_X_TOKEN, new_creds.x_token.get_secret(), encrypted=True)
-        self._update_config_value(
-            CONF_REFRESH_TOKEN, new_refresh_token.get_secret(), encrypted=True
-        )
-        restrictive = bool(self.config.get_value(CONF_RESTRICTIVE_RATE_LIMITS, False))
-        self._client = YandexMusicClient(
-            new_music_token, base_url=base_url, restrictive_rate_limits=restrictive
-        )
-        await self._client.connect()
-        self.logger.info("Re-issued credentials silently from refresh token")
-
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
         token = self.config.get_value(CONF_TOKEN)
@@ -712,6 +640,965 @@ class YandexMusicProvider(MusicProvider):
         if len(folders) == 1:
             return await self.browse(folders[0].path)
         return folders
+
+    # Search
+
+    @use_cache(3600 * 24, allow_expired_cache=True)
+    async def search(
+        self, search_query: str, media_types: list[MediaType], limit: int = 5
+    ) -> SearchResults:
+        """
+        Perform search on Yandex Music.
+
+        :param search_query: The search query.
+        :param media_types: List of media types to search for.
+        :param limit: Maximum number of results per type.
+        :return: SearchResults with found items.
+        """
+        result = SearchResults()
+
+        # Determine search type based on requested media types
+        # Map MediaType to Yandex API search type. AUDIOBOOK has no dedicated
+        # Yandex type — it maps to "album" and is filtered by classify_album below.
+        type_mapping = {
+            MediaType.TRACK: "track",
+            MediaType.ALBUM: "album",
+            MediaType.AUDIOBOOK: "album",
+            MediaType.ARTIST: "artist",
+            MediaType.PLAYLIST: "playlist",
+            MediaType.PODCAST: "podcast",
+        }
+        requested_types = list(
+            dict.fromkeys(type_mapping[mt] for mt in media_types if mt in type_mapping)
+        )
+
+        # Use specific type if only one requested, otherwise search all
+        search_type = requested_types[0] if len(requested_types) == 1 else "all"
+
+        search_result = await self.client.search(search_query, search_type=search_type)
+        if not search_result:
+            return result
+
+        # Parse tracks
+        if MediaType.TRACK in media_types and search_result.tracks:
+            for track in search_result.tracks.results[:limit]:
+                try:
+                    result.tracks = [*result.tracks, parse_track(self, track)]
+                except InvalidDataError as err:
+                    self.logger.debug("Error parsing track: %s", err)
+
+        # Parse albums — audiobooks are split into the audiobooks bucket via
+        # classify_album. Yandex-returned podcast albums are handled separately
+        # through the dedicated `.podcasts` node below. ``limit`` is applied per
+        # bucket AFTER classification — slicing first would drop audiobooks when
+        # the first ``limit`` results happen to be music albums (or vice versa).
+        want_album = MediaType.ALBUM in media_types
+        want_audiobook = MediaType.AUDIOBOOK in media_types
+        if (want_album or want_audiobook) and search_result.albums:
+            album_count = 0
+            audiobook_count = 0
+            for album in search_result.albums.results:
+                album_full = not want_album or album_count >= limit
+                audiobook_full = not want_audiobook or audiobook_count >= limit
+                if album_full and audiobook_full:
+                    break
+                kind = classify_album(album)
+                try:
+                    if kind == "audiobook" and want_audiobook and not audiobook_full:
+                        result.audiobooks = [
+                            *result.audiobooks,
+                            parse_audiobook(self, album),
+                        ]
+                        audiobook_count += 1
+                    elif kind == "music" and want_album and not album_full:
+                        result.albums = [*result.albums, parse_album(self, album)]
+                        album_count += 1
+                except InvalidDataError as err:
+                    self.logger.debug("Error parsing %s album: %s", kind, err)
+
+        # Parse artists
+        if MediaType.ARTIST in media_types and search_result.artists:
+            for artist in search_result.artists.results[:limit]:
+                try:
+                    result.artists = [*result.artists, parse_artist(self, artist)]
+                except InvalidDataError as err:
+                    self.logger.debug("Error parsing artist: %s", err)
+
+        # Parse playlists
+        if MediaType.PLAYLIST in media_types and search_result.playlists:
+            for playlist in search_result.playlists.results[:limit]:
+                try:
+                    result.playlists = [*result.playlists, parse_playlist(self, playlist)]
+                except InvalidDataError as err:
+                    self.logger.debug("Error parsing playlist: %s", err)
+
+        # Parse podcasts (Yandex returns them as albums under .podcasts)
+        podcasts_node = getattr(search_result, "podcasts", None)
+        if MediaType.PODCAST in media_types and podcasts_node:
+            for album in podcasts_node.results[:limit]:
+                try:
+                    result.podcasts = [*result.podcasts, parse_podcast(self, album)]
+                except InvalidDataError as err:
+                    self.logger.debug("Error parsing podcast: %s", err)
+
+        return result
+
+    # Get single items
+
+    @use_cache(3600 * 24 * 30, allow_expired_cache=True)
+    async def get_artist(self, prov_artist_id: str) -> Artist:
+        """
+        Get artist details by ID, enriched with description and listener stats.
+
+        :param prov_artist_id: The provider artist ID.
+        :return: Artist object.
+        :raises MediaNotFoundError: If artist not found.
+        """
+        artist, about = await asyncio.gather(
+            self.client.get_artist(prov_artist_id),
+            self.client.get_artist_about(prov_artist_id),
+        )
+        if not artist:
+            raise MediaNotFoundError(f"Artist {prov_artist_id} not found")
+        return parse_artist(self, artist, about=about)
+
+    @use_cache(3600 * 24 * 30, allow_expired_cache=True)
+    async def get_album(self, prov_album_id: str) -> Album:
+        """
+        Get album details by ID.
+
+        :param prov_album_id: The provider album ID.
+        :return: Album object.
+        :raises MediaNotFoundError: If album not found.
+        """
+        album = await self.client.get_album(prov_album_id)
+        if not album:
+            raise MediaNotFoundError(f"Album {prov_album_id} not found")
+        return parse_album(self, album)
+
+    @use_cache(3600 * 24, allow_expired_cache=True)
+    async def get_podcast(self, prov_podcast_id: str) -> Podcast:
+        """
+        Get podcast details by ID (backed by a Yandex album).
+
+        :param prov_podcast_id: The provider podcast (album) ID.
+        :return: Podcast object.
+        :raises MediaNotFoundError: If not found.
+        """
+        album = await self.client.get_album(prov_podcast_id)
+        if not album:
+            raise MediaNotFoundError(f"Podcast {prov_podcast_id} not found")
+        return parse_podcast(self, album)
+
+    async def get_podcast_episodes(self, prov_podcast_id: str) -> AsyncGenerator[PodcastEpisode]:
+        """Iterate podcast episodes for a given podcast (album) ID."""
+        album = await self.client.get_album_with_tracks(prov_podcast_id)
+        if not album:
+            raise MediaNotFoundError(f"Podcast {prov_podcast_id} not found")
+        podcast = parse_podcast(self, album)
+        position = 1
+        for disc in album.volumes or []:
+            for track_obj in disc:
+                try:
+                    yield parse_podcast_episode(self, track_obj, podcast, position=position)
+                except InvalidDataError as err:
+                    self.logger.debug("Error parsing podcast episode: %s", err)
+                position += 1
+
+    async def get_podcast_episode(self, prov_episode_id: str) -> PodcastEpisode:
+        """
+        Get a single podcast episode by ID.
+
+        The parent Podcast is reconstructed from the track's parent album. If
+        the album isn't present on the track, the episode cannot be converted
+        into a valid MA model and InvalidDataError is raised.
+        """
+        tracks = await self.client.get_tracks([prov_episode_id])
+        if not tracks:
+            raise MediaNotFoundError(f"Podcast episode {prov_episode_id} not found")
+        track_obj = tracks[0]
+        if not track_obj.albums:
+            raise InvalidDataError(
+                f"Podcast episode {prov_episode_id} is missing parent podcast album data"
+            )
+        podcast = parse_podcast(self, track_obj.albums[0])
+        return parse_podcast_episode(self, track_obj, podcast, position=0)
+
+    @use_cache(3600 * 24, allow_expired_cache=True)
+    async def get_audiobook(self, prov_audiobook_id: str) -> Audiobook:
+        """
+        Get audiobook details by ID, including chapters built from tracks.
+
+        :param prov_audiobook_id: The provider audiobook (album) ID.
+        :return: Audiobook object.
+        :raises MediaNotFoundError: If not found.
+        """
+        album = await self.client.get_album_with_tracks(prov_audiobook_id)
+        if not album:
+            raise MediaNotFoundError(f"Audiobook {prov_audiobook_id} not found")
+        audiobook = parse_audiobook(self, album)
+
+        chapters: list[MediaItemChapter] = []
+        start = 0.0
+        pos = 1
+        for disc in album.volumes or []:
+            for track_obj in disc:
+                dur_s = (track_obj.duration_ms or 0) / 1000.0
+                chapters.append(
+                    MediaItemChapter(
+                        position=pos,
+                        name=track_obj.title or f"Chapter {pos}",
+                        start=start,
+                        end=start + dur_s,
+                    )
+                )
+                start += dur_s
+                pos += 1
+        audiobook.metadata.chapters = chapters
+        audiobook.duration = int(start)
+        return audiobook
+
+    async def get_track(self, prov_track_id: str) -> Track:
+        """
+        Get track details by ID.
+
+        Supports composite item_id (track_id@station_id) for My Wave tracks;
+        only the track_id part is used for the API. Normalizes the ID before
+        caching to avoid duplicate cache entries.
+
+        :param prov_track_id: The provider track ID (or track_id@station_id).
+        :return: Track object.
+        :raises MediaNotFoundError: If track not found.
+        """
+        track_id, _ = _parse_radio_item_id(prov_track_id)
+        return await self._get_track_cached(track_id)
+
+    async def get_playlist(self, prov_playlist_id: str) -> Playlist:
+        """
+        Get playlist details by ID.
+
+        Supports virtual playlists MY_WAVE_PLAYLIST_ID (My Wave) and
+        LIKED_TRACKS_PLAYLIST_ID (Liked Tracks). Real playlists use format "owner_id:kind".
+
+        :param prov_playlist_id: The provider playlist ID (format: "owner_id:kind",
+            my_wave, or liked_tracks).
+        :return: Playlist object.
+        :raises MediaNotFoundError: If playlist not found.
+        """
+        # Virtual playlists - constructed locally (no API call); translation_key localizes
+        # the name for the connection locale at serialization.
+        if prov_playlist_id == MY_WAVE_PLAYLIST_ID:
+            return Playlist(
+                item_id=MY_WAVE_PLAYLIST_ID,
+                provider=self.instance_id,
+                name="My Wave",
+                translation_key=MY_WAVE_PLAYLIST_ID,
+                owner=get_canonical_provider_name(self),
+                provider_mappings={
+                    ProviderMapping(
+                        item_id=MY_WAVE_PLAYLIST_ID,
+                        provider_domain=self.domain,
+                        provider_instance=self.instance_id,
+                        is_unique=True,
+                    )
+                },
+                is_editable=False,
+            )
+
+        if prov_playlist_id == LIKED_TRACKS_PLAYLIST_ID:
+            return Playlist(
+                item_id=LIKED_TRACKS_PLAYLIST_ID,
+                provider=self.instance_id,
+                name="My Favorites",
+                translation_key=LIKED_TRACKS_PLAYLIST_ID,
+                owner=get_canonical_provider_name(self),
+                provider_mappings={
+                    ProviderMapping(
+                        item_id=LIKED_TRACKS_PLAYLIST_ID,
+                        provider_domain=self.domain,
+                        provider_instance=self.instance_id,
+                        is_unique=True,
+                    )
+                },
+                is_editable=False,
+            )
+
+        # Real playlists - use cached method
+        return await self._get_real_playlist(prov_playlist_id)
+
+    # Get related items
+
+    @use_cache(3600 * 24 * 30, allow_expired_cache=True)
+    async def get_album_tracks(self, prov_album_id: str) -> list[Track]:
+        """
+        Get album tracks.
+
+        :param prov_album_id: The provider album ID.
+        :return: List of Track objects.
+        """
+        album = await self.client.get_album_with_tracks(prov_album_id)
+        if not album or not album.volumes:
+            return []
+
+        tracks = []
+        for volume_index, volume in enumerate(album.volumes):
+            for track_index, track in enumerate(volume):
+                try:
+                    parsed_track = parse_track(self, track)
+                    parsed_track.disc_number = volume_index + 1
+                    parsed_track.track_number = track_index + 1
+                    tracks.append(parsed_track)
+                except InvalidDataError as err:
+                    self.logger.debug("Error parsing album track: %s", err)
+        return tracks
+
+    async def get_similar_tracks(self, prov_track_id: str, limit: int = 25) -> list[Track]:
+        """
+        Get similar tracks, preferring pre-fetched wave tracks when available.
+
+        Split in two paths with different caching policies:
+
+        - **Wave-drain path** (the seed carries a station suffix and
+          ``wave.prefetched`` is non-empty). Uncached by design: it mutates
+          state, a cache hit would replay the same drained tracks forever and
+          the prefetch buffer would never advance.
+        - **Fallback path** (plain track_id, no active wave, or empty buffer).
+          Creates a per-seed rotor session under ``track:{id}`` and is cached
+          for 3 hours — this is pure and safe to memoise.
+
+        :param prov_track_id: Provider track ID (plain or track_id@station_id).
+        :param limit: Maximum number of tracks to return.
+        :return: List of similar Track objects.
+        """
+        track_id, station_key = _parse_radio_item_id(prov_track_id)
+
+        if station_key:
+            drained = await self._drain_prefetched_wave_tracks(station_key, limit)
+            if drained:
+                return drained
+
+        return await self._fetch_similar_tracks_for_seed(track_id, limit)
+
+    @use_cache(3600 * 3, allow_expired_cache=True)
+    async def get_similar_artists(self, prov_artist_id: str, limit: int = 25) -> list[Artist]:
+        """
+        Get artists similar to the given one via Yandex artists/similar endpoint.
+
+        :param prov_artist_id: Provider artist ID.
+        :param limit: Maximum number of artists to return.
+        :return: List of similar Artist objects.
+        """
+        yandex_artists = await self.client.get_similar_artists(prov_artist_id, limit=limit)
+        artists: list[Artist] = []
+        for ya in yandex_artists:
+            try:
+                artists.append(parse_artist(self, ya))
+            except InvalidDataError as err:
+                self.logger.debug("Error parsing similar artist: %s", err)
+        return artists
+
+    async def recommendations(self) -> list[RecommendationFolder]:
+        """
+        Get recommendations with multiple discovery folders.
+
+        Returns My Wave, Feed (Made for You), Chart, New Releases, and
+        New Playlists sections.
+
+        :return: List of recommendation folders.
+        """
+        folders: list[RecommendationFolder] = []
+
+        folder = await self._get_my_wave_recommendations()
+        if folder:
+            folders.append(folder)
+
+        folder = await self._get_feed_recommendations()
+        if folder:
+            folders.append(folder)
+
+        folder = await self._get_chart_recommendations()
+        if folder:
+            folders.append(folder)
+
+        folder = await self._get_new_releases_recommendations()
+        if folder:
+            folders.append(folder)
+
+        folder = await self._get_new_playlists_recommendations()
+        if folder:
+            folders.append(folder)
+
+        # Picks & Mixes recommendations
+        folder = await self._get_top_picks_recommendations()
+        if folder:
+            folders.append(folder)
+
+        # Mood mix: select tag outside cache so rotation actually works
+        mood_tag = await self._pick_random_tag_for_category("mood")
+        if mood_tag:
+            folder = await self._get_mood_mix_recommendations(mood_tag)
+            if folder:
+                folders.append(folder)
+
+        # Activity mix: select tag outside cache so rotation actually works
+        activity_tag = await self._pick_random_tag_for_category("activity")
+        if activity_tag:
+            folder = await self._get_activity_mix_recommendations(activity_tag)
+            if folder:
+                folders.append(folder)
+
+        folder = await self._get_seasonal_mix_recommendations()
+        if folder:
+            folders.append(folder)
+
+        return folders
+
+    @use_cache(3600 * 3, allow_expired_cache=True)
+    async def get_playlist_tracks(self, prov_playlist_id: str, page: int = 0) -> list[Track]:
+        """
+        Get playlist tracks.
+
+        :param prov_playlist_id: The provider playlist ID (format: "owner_id:kind",
+            my_wave, or liked_tracks).
+        :param page: Page number for pagination.
+        :return: List of Track objects.
+        """
+        self.logger.debug(
+            "get_playlist_tracks called: prov_playlist_id=%s, page=%s", prov_playlist_id, page
+        )
+
+        if prov_playlist_id == MY_WAVE_PLAYLIST_ID:
+            self.logger.debug("Fetching My Wave tracks")
+            return await self._get_my_wave_playlist_tracks(page)
+
+        if prov_playlist_id == LIKED_TRACKS_PLAYLIST_ID:
+            self.logger.debug("Fetching Liked Tracks for virtual playlist")
+            result = await self._get_liked_tracks_playlist_tracks(page)
+            self.logger.debug("Liked Tracks playlist returned %s tracks", len(result))
+            return result
+
+        # Yandex Music API returns all playlist tracks in one call (no server-side pagination).
+        # Return empty list for page > 0 so the controller pagination loop terminates.
+        if page > 0:
+            return []
+
+        # Parse the playlist ID (format: owner_id:kind)
+        if PLAYLIST_ID_SPLITTER in prov_playlist_id:
+            owner_id, kind = prov_playlist_id.split(PLAYLIST_ID_SPLITTER, 1)
+        else:
+            owner_id = str(self.client.user_id)
+            kind = prov_playlist_id
+
+        playlist = await self.client.get_playlist(owner_id, kind)
+        if not playlist:
+            return []
+
+        # API sometimes returns playlist without tracks; fetch them explicitly if needed
+        tracks_list = playlist.tracks or []
+        track_count = getattr(playlist, "track_count", None) or 0
+        if not tracks_list and track_count > 0:
+            self.logger.debug(
+                "Playlist %s/%s: track_count=%s but no tracks in response, "
+                "calling fetch_tracks_async",
+                owner_id,
+                kind,
+                track_count,
+            )
+            try:
+                tracks_list = await playlist.fetch_tracks_async()
+            except Exception as err:
+                self.logger.warning("fetch_tracks_async failed for %s/%s: %s", owner_id, kind, err)
+            if not tracks_list:
+                raise ResourceTemporarilyUnavailable(
+                    "Playlist tracks not available; try again later"
+                )
+
+        if not tracks_list:
+            return []
+
+        # Yandex returns TrackShort objects, we need to fetch full track info
+        track_ids = [
+            str(track.track_id) if hasattr(track, "track_id") else str(track.id)
+            for track in tracks_list
+            if track
+        ]
+        if not track_ids:
+            return []
+
+        # Fetch full track details in batches to avoid timeouts
+        batch_size = TRACK_BATCH_SIZE
+        full_tracks = []
+        for i in range(0, len(track_ids), batch_size):
+            batch = track_ids[i : i + batch_size]
+            batch_result = await self.client.get_tracks(batch)
+            if not batch_result:
+                # Skip this batch but keep going — the terminal guard below
+                # raises if every batch comes back empty. Aborting on a single
+                # empty batch threw away tracks already fetched from earlier
+                # batches and forced a full retry hours later (under the
+                # @use_cache TTL above).
+                self.logger.warning(
+                    "Empty batch %s-%s for playlist %s, skipping",
+                    i,
+                    i + len(batch) - 1,
+                    prov_playlist_id,
+                )
+                continue
+            full_tracks.extend(batch_result)
+
+        if track_ids and not full_tracks:
+            raise ResourceTemporarilyUnavailable("Failed to load track details; try again later")
+
+        tracks = []
+        for track in full_tracks:
+            try:
+                tracks.append(parse_track(self, track))
+            except InvalidDataError as err:
+                self.logger.debug("Error parsing playlist track: %s", err)
+        return tracks
+
+    @use_cache(3600 * 24 * 7, allow_expired_cache=True)
+    async def get_artist_albums(self, prov_artist_id: str) -> list[Album]:
+        """
+        Get artist's albums.
+
+        :param prov_artist_id: The provider artist ID.
+        :return: List of Album objects.
+        """
+        albums = await self.client.get_artist_albums(prov_artist_id)
+        result = []
+        for album in albums:
+            try:
+                result.append(parse_album(self, album))
+            except InvalidDataError as err:
+                self.logger.debug("Error parsing artist album: %s", err)
+        return result
+
+    @use_cache(3600 * 24 * 7, allow_expired_cache=True)
+    async def get_artist_toptracks(self, prov_artist_id: str) -> list[Track]:
+        """
+        Get artist's top tracks.
+
+        :param prov_artist_id: The provider artist ID.
+        :return: List of Track objects.
+        """
+        tracks = await self.client.get_artist_tracks(prov_artist_id)
+        result = []
+        for track in tracks:
+            try:
+                result.append(parse_track(self, track))
+            except InvalidDataError as err:
+                self.logger.debug("Error parsing artist track: %s", err)
+        return result
+
+    # Library methods
+
+    async def get_library_artists(self) -> AsyncGenerator[Artist]:
+        """Retrieve library artists from Yandex Music."""
+        artists = await self.client.get_liked_artists()
+        for artist in artists:
+            try:
+                yield parse_artist(self, artist)
+            except InvalidDataError as err:
+                self.logger.debug("Error parsing library artist: %s", err)
+
+    async def get_library_albums(self) -> AsyncGenerator[Album]:
+        """
+        Retrieve library albums from Yandex Music.
+
+        Excludes entries classified as podcasts or audiobooks so they don't
+        duplicate into the Albums library view.
+        """
+        for album in await self._get_liked_albums_cached():
+            if classify_album(album) != "music":
+                continue
+            try:
+                yield parse_album(self, album)
+            except InvalidDataError as err:
+                self.logger.debug("Error parsing library album: %s", err)
+
+    async def get_library_podcasts(self) -> AsyncGenerator[Podcast]:
+        """Retrieve library podcasts from Yandex Music (filtered liked albums)."""
+        for album in await self._get_liked_albums_cached():
+            if classify_album(album) != "podcast":
+                continue
+            try:
+                yield parse_podcast(self, album)
+            except InvalidDataError as err:
+                self.logger.debug("Error parsing library podcast: %s", err)
+
+    async def get_library_audiobooks(self) -> AsyncGenerator[Audiobook]:
+        """Retrieve library audiobooks from Yandex Music (filtered liked albums)."""
+        for album in await self._get_liked_albums_cached():
+            if classify_album(album) != "audiobook":
+                continue
+            try:
+                yield parse_audiobook(self, album)
+            except InvalidDataError as err:
+                self.logger.debug("Error parsing library audiobook: %s", err)
+
+    async def get_library_tracks(self) -> AsyncGenerator[Track]:
+        """Retrieve library tracks from Yandex Music."""
+        track_shorts = await self.client.get_liked_tracks()
+        if not track_shorts:
+            return
+
+        # Fetch full track details in batches
+        track_ids = [str(ts.track_id) for ts in track_shorts if ts.track_id]
+        batch_size = TRACK_BATCH_SIZE
+        for i in range(0, len(track_ids), batch_size):
+            batch_ids = track_ids[i : i + batch_size]
+            full_tracks = await self.client.get_tracks(batch_ids)
+            for track in full_tracks:
+                try:
+                    yield parse_track(self, track)
+                except InvalidDataError as err:
+                    self.logger.debug("Error parsing library track: %s", err)
+
+    async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
+        """
+        Retrieve library playlists from Yandex Music.
+
+        Includes virtual playlists (My Wave and Liked Tracks if enabled), user-created playlists,
+        and user-liked editorial playlists (returned by a separate API endpoint).
+        """
+        yield await self.get_playlist(MY_WAVE_PLAYLIST_ID)
+        yield await self.get_playlist(LIKED_TRACKS_PLAYLIST_ID)
+        seen_ids: set[str] = set()
+        # User-created playlists
+        playlists = await self.client.get_user_playlists()
+        for playlist in playlists:
+            try:
+                parsed = parse_playlist(self, playlist)
+                seen_ids.add(parsed.item_id)
+                yield parsed
+            except InvalidDataError as err:
+                self.logger.debug("Error parsing library playlist: %s", err)
+        # User-liked editorial playlists (not in users_playlists_list)
+        liked_playlists = await self.client.get_liked_playlists()
+        for playlist in liked_playlists:
+            try:
+                parsed = parse_playlist(self, playlist)
+                if parsed.item_id not in seen_ids:
+                    yield parsed
+            except InvalidDataError as err:
+                self.logger.debug("Error parsing liked playlist: %s", err)
+
+    # Library edit methods
+
+    async def library_add(self, item: MediaItemType) -> bool:
+        """
+        Add item to library.
+
+        For tracks carrying a wave station context in the item_id (e.g. when
+        the user adds a My Wave track to favourites during playback), also
+        fires a rotor ``like`` feedback on the active session so the wave
+        algorithm biases toward similar tracks immediately.
+
+        :param item: The media item to add.
+        :return: True if successful.
+        """
+        prov_item_id = self._get_provider_item_id(item)
+        if not prov_item_id:
+            return False
+        track_id, station_key = _parse_radio_item_id(prov_item_id)
+
+        if item.media_type == MediaType.TRACK:
+            ok = await self.client.like_track(track_id)
+            if ok and station_key:
+                wave = self._wave_states.get(station_key)
+                if wave and wave.session_id:
+                    await self._send_wave_feedback(wave, station_key, "like", track_id=track_id)
+            return ok
+        if item.media_type in (MediaType.ALBUM, MediaType.PODCAST, MediaType.AUDIOBOOK):
+            return await self.client.like_album(prov_item_id)
+        if item.media_type == MediaType.ARTIST:
+            return await self.client.like_artist(prov_item_id)
+        return False
+
+    async def library_remove(self, prov_item_id: str, media_type: MediaType) -> bool:
+        """
+        Remove item from library.
+
+        :param prov_item_id: The provider item ID (may be track_id@station_id for tracks).
+        :param media_type: The media type.
+        :return: True if successful.
+        """
+        track_id, _ = _parse_radio_item_id(prov_item_id)
+        if media_type == MediaType.TRACK:
+            return await self.client.unlike_track(track_id)
+        if media_type in (MediaType.ALBUM, MediaType.PODCAST, MediaType.AUDIOBOOK):
+            return await self.client.unlike_album(prov_item_id)
+        if media_type == MediaType.ARTIST:
+            return await self.client.unlike_artist(prov_item_id)
+        return False
+
+    # Streaming
+
+    async def get_stream_details(
+        self, item_id: str, media_type: MediaType = MediaType.TRACK
+    ) -> StreamDetails:
+        """
+        Get stream details for a track, podcast episode, or audiobook.
+
+        A podcast episode is a track underneath the Yandex API, so it flows
+        through the same per-track streaming path. An audiobook is an album
+        with multiple tracks (chapters) — returned as a CUSTOM stream whose
+        generator concatenates each chapter's bytes in order.
+
+        :param item_id: The track / episode ID (or track_id@station_id for My Wave),
+            or the audiobook (album) ID when ``media_type`` is AUDIOBOOK.
+        :param media_type: The media type.
+        :return: StreamDetails for the item.
+        """
+        if media_type == MediaType.AUDIOBOOK:
+            return await self._get_audiobook_stream_details(item_id)
+        return await self.streaming.get_stream_details(item_id)
+
+    async def get_audio_stream(
+        self, streamdetails: StreamDetails, seek_position: int = 0
+    ) -> AsyncGenerator[bytes]:
+        """
+        Return the audio stream for the provider item.
+
+        For tracks and podcast episodes, streams via windowed Range requests
+        (raw or AES-CTR encrypted). For audiobooks, iterates chapters: each
+        chapter's bytes are streamed through the per-track path and concatenated.
+
+        :param streamdetails: Stream details with URL and optional decryption key.
+        :param seek_position: Seek position in seconds (handled by provider for raw transport).
+        :return: Async generator yielding audio chunks.
+        """
+        data = streamdetails.data if isinstance(streamdetails.data, dict) else None
+        if streamdetails.media_type == MediaType.AUDIOBOOK and data and "chapter_ids" in data:
+            async for chunk in self._stream_audiobook_chapters(data, seek_position):
+                yield chunk
+            return
+        async for chunk in self.streaming.get_audio_stream(streamdetails, seek_position):
+            yield chunk
+
+    async def get_rotor_station_tracks(
+        self, station_id: str, queue: str | int | None = None
+    ) -> tuple[list[Any], str | None]:
+        """
+        Fetch tracks from a rotor station using the session API.
+
+        Public surface — pinned by the ynison plugin
+        (`YandexMusicProviderLike.get_rotor_station_tracks`). The
+        ``(tracks, batch_id)`` return contract is kept for that caller even
+        though batch_id is now a session-scoped identifier.
+
+        Routes to ``_fetch_rotor_session_batch`` so the wave session state
+        (`session_id`, seen tracks, prefetch) is shared with our own Browse /
+        on_played / on_streamed flows. ``queue`` is the most recently played
+        track ID the external caller observed — we record it as the
+        pagination cursor before calling through.
+
+        :param station_id: Rotor station ID (e.g. "user:onyourwave",
+            "genre:rock", "mood:calm", "track:1234").
+        :param queue: Last-played track ID for pagination. Ignored on the
+            very first call (no session yet) but still recorded.
+        :return: Tuple of (list of yandex tracks, batch_id or None).
+        """
+        wave = self._get_wave_state(station_id)
+        # Cursor update + batch fetch run under the station's lock, matching
+        # the discipline in browse / recommendations / prefetch. Without it,
+        # ynison replenish racing with a concurrent MA browse could interleave
+        # last_track_id writes and leave session_id / batch_id out of sync.
+        async with wave.lock:
+            if queue is not None:
+                wave.last_track_id = str(queue)
+            return await self._fetch_rotor_session_batch(wave, station_id)
+
+    def get_quality(self) -> str:
+        """Return the configured audio quality tier (e.g. 'balanced', 'superb')."""
+        quality = str(self.config.get_value(CONF_QUALITY) or QUALITY_BALANCED).strip().lower()
+        if quality == "lossless":
+            quality = QUALITY_SUPERB
+        return quality
+
+    async def resolve_image(self, path: str) -> str | bytes:
+        """
+        Resolve wave cover image with background color fill for transparent PNGs.
+
+        If the image URL has an associated background color (stored in _wave_bg_colors),
+        downloads the PNG from Yandex CDN and composites it on a solid color background
+        using Pillow, returning JPEG bytes. Falls back to the original URL on any error.
+
+        :param path: Image URL (may include #rrggbb fragment used as cache key).
+        :return: Composited JPEG bytes, or original path string as fallback.
+        """
+        bg_color = self._wave_bg_colors.get(path)
+        if not bg_color:
+            return path
+
+        # Strip the #color fragment before fetching the actual image
+        fetch_url = path.split("#", maxsplit=1)[0] if "#" in path else path
+        try:
+            async with self.mass.http_session.get(fetch_url) as resp:
+                resp.raise_for_status()
+                raw = await resp.read()
+        except Exception as err:
+            self.logger.debug("Failed to fetch wave cover %s: %s", fetch_url, err)
+            return fetch_url
+
+        def _composite() -> bytes:
+            bg_clean = bg_color.lstrip("#")
+            try:
+                r = int(bg_clean[0:2], 16)
+                g = int(bg_clean[2:4], 16)
+                b = int(bg_clean[4:6], 16)
+            except ValueError, IndexError:
+                return raw
+            fg = PilImage.open(BytesIO(raw)).convert("RGBA")
+            bg = PilImage.new("RGBA", fg.size, (r, g, b, 255))
+            bg.paste(fg, mask=fg)
+            out = BytesIO()
+            bg.convert("RGB").save(out, "JPEG", quality=92)
+            return out.getvalue()
+
+        try:
+            return await asyncio.to_thread(_composite)
+        except Exception as err:
+            self.logger.debug("Wave cover composite failed for %s: %s", fetch_url, err)
+            return fetch_url
+
+    async def on_played(
+        self,
+        media_type: MediaType,
+        prov_item_id: str,
+        fully_played: bool,
+        position: int,
+        media_item: MediaItemType,
+        is_playing: bool = False,
+    ) -> None:
+        """
+        Report periodic playback updates.
+
+        - Audiobooks: persist chapter progress via play_audio so Yandex's
+          own clients resume at the right point.
+        - Wave tracks: send rotor ``trackStarted`` while actively playing and
+          kick off a background prefetch so DSTM refill serves wave-curated
+          tracks with no extra round-trip. DSTM itself is the user's toggle —
+          the provider does not flip it.
+
+        Generic track history reporting is not attempted here — the only
+        known channel Yandex writes into ``/handlers/music-history`` is a
+        long-lived Ynison WebSocket session, which lives in the sibling
+        yandex_ynison plugin. Regular tracks played through MA are therefore
+        invisible to Listening History unless that plugin is also active.
+        """
+        if media_type == MediaType.AUDIOBOOK:
+            await self._report_audiobook_progress(prov_item_id, position)
+            return
+        if media_type != MediaType.TRACK:
+            return
+        _, station_id = _parse_radio_item_id(prov_item_id)
+        if station_id and is_playing:
+            track_id, _ = _parse_radio_item_id(prov_item_id)
+            wave = self._wave_states.get(station_id) or self._get_wave_state(station_id)
+            await self._send_wave_feedback(wave, station_id, "trackStarted", track_id=track_id)
+            self.mass.create_task(self._prefetch_rotor_session(station_id))
+
+    async def on_streamed(self, streamdetails: StreamDetails) -> None:
+        """
+        Report stream completion to Yandex.
+
+        - Audiobooks: a final ``play_audio`` with the absolute stream
+          position so the last listening point is preserved across Yandex
+          clients. Cleans up session state even when ``data`` was stripped.
+        - Wave tracks (composite item_id carries a station suffix): a rotor
+          ``trackFinished`` or ``skip`` event with the actual seconds streamed
+          so Yandex can improve recommendations.
+        """
+        data = streamdetails.data if isinstance(streamdetails.data, dict) else None
+        if streamdetails.media_type == MediaType.AUDIOBOOK:
+            await self._report_audiobook_final(streamdetails, data or {})
+            return
+        if streamdetails.media_type != MediaType.TRACK:
+            return
+        track_id, station_id = _parse_radio_item_id(streamdetails.item_id)
+        if not station_id:
+            return
+        seconds = int(streamdetails.seconds_streamed or 0)
+        duration = int(streamdetails.duration or 0)
+        feedback_type = "trackFinished" if duration and seconds >= max(0, duration - 10) else "skip"
+        wave = self._wave_states.get(station_id) or self._get_wave_state(station_id)
+        await self._send_wave_feedback(
+            wave, station_id, feedback_type, track_id=track_id, total_played_seconds=seconds
+        )
+
+    def _media_label(self, group: str, key: str, fallback: str) -> tuple[str, str | None]:
+        """
+        Resolve a media label to its English ``name`` and ``translation_key``.
+
+        The English source string lives in the provider's ``strings.json`` (the single source
+        of truth) and is localized for the connection locale at serialization via the returned
+        key. An unauthored key — e.g. a tag discovered from Yandex's landing API — returns
+        ``(fallback, None)`` so its already-localized name is kept verbatim.
+
+        :param group: Media translation group (``folder``, ``recommendations`` or ``playlist``).
+        :param key: Authoring key within the group; also the item's ``translation_key``.
+        :param fallback: English name to use when no string is authored for *key*.
+        """
+        authored = self.mass.translations.get_translation(
+            f"provider.{self.domain}.media.{group}.{key}.name"
+        )
+        if authored is None:
+            return fallback, None
+        return authored, key
+
+    async def _reauth_via_refresh_token(
+        self, x_token: str, refresh_token: str, base_url: str, original_err: Exception
+    ) -> None:
+        """
+        Silently re-issue full credentials when x_token refresh fails.
+
+        Device-flow accounts have a refresh_token that can mint a new
+        x_token + refresh_token + music_token without any user interaction.
+        Persists the rotated triple and connects the client. Any failure
+        here is terminal — clears all credentials and forces re-auth.
+        """
+        try:
+            new_creds = await refresh_credentials_via_passport(
+                SecretStr(x_token), SecretStr(refresh_token)
+            )
+        except ResourceTemporarilyUnavailable as err2:
+            # Transient Passport failure — keep creds, let MA retry later
+            self.logger.warning(
+                "Credential refresh temporarily unavailable: %s", type(err2).__name__
+            )
+            raise ProviderUnavailableError(
+                "Unable to refresh credentials right now. Please try again later."
+            ) from err2
+        except LoginFailed as err2:
+            self.logger.warning("Session and refresh tokens are both expired")
+            self._update_config_value(CONF_TOKEN, None, encrypted=True)
+            self._update_config_value(CONF_X_TOKEN, None, encrypted=True)
+            self._update_config_value(CONF_REFRESH_TOKEN, None, encrypted=True)
+            raise LoginFailed("Session expired. Please re-authenticate.") from err2
+
+        new_music_token = new_creds.music_token
+        new_refresh_token = new_creds.refresh_token
+        if new_music_token is None or new_refresh_token is None:
+            self._update_config_value(CONF_TOKEN, None, encrypted=True)
+            self._update_config_value(CONF_X_TOKEN, None, encrypted=True)
+            self._update_config_value(CONF_REFRESH_TOKEN, None, encrypted=True)
+            raise LoginFailed(
+                "Credential refresh returned an incomplete response."
+            ) from original_err
+
+        self._update_config_value(CONF_TOKEN, new_music_token.get_secret(), encrypted=True)
+        self._update_config_value(CONF_X_TOKEN, new_creds.x_token.get_secret(), encrypted=True)
+        self._update_config_value(
+            CONF_REFRESH_TOKEN, new_refresh_token.get_secret(), encrypted=True
+        )
+        restrictive = bool(self.config.get_value(CONF_RESTRICTIVE_RATE_LIMITS, False))
+        self._client = YandexMusicClient(
+            new_music_token, base_url=base_url, restrictive_rate_limits=restrictive
+        )
+        await self._client.connect()
+        self.logger.info("Re-issued credentials silently from refresh token")
 
     async def _browse_my_wave(
         self, path: str, sub_subpath: str | None
@@ -2031,238 +2918,6 @@ class YandexMusicProvider(MusicProvider):
         self.logger.debug("Parsed %d playlists for tag %s", len(result), tag_id)
         return result
 
-    # Search
-
-    @use_cache(3600 * 24, allow_expired_cache=True)
-    async def search(
-        self, search_query: str, media_types: list[MediaType], limit: int = 5
-    ) -> SearchResults:
-        """
-        Perform search on Yandex Music.
-
-        :param search_query: The search query.
-        :param media_types: List of media types to search for.
-        :param limit: Maximum number of results per type.
-        :return: SearchResults with found items.
-        """
-        result = SearchResults()
-
-        # Determine search type based on requested media types
-        # Map MediaType to Yandex API search type. AUDIOBOOK has no dedicated
-        # Yandex type — it maps to "album" and is filtered by classify_album below.
-        type_mapping = {
-            MediaType.TRACK: "track",
-            MediaType.ALBUM: "album",
-            MediaType.AUDIOBOOK: "album",
-            MediaType.ARTIST: "artist",
-            MediaType.PLAYLIST: "playlist",
-            MediaType.PODCAST: "podcast",
-        }
-        requested_types = list(
-            dict.fromkeys(type_mapping[mt] for mt in media_types if mt in type_mapping)
-        )
-
-        # Use specific type if only one requested, otherwise search all
-        search_type = requested_types[0] if len(requested_types) == 1 else "all"
-
-        search_result = await self.client.search(search_query, search_type=search_type)
-        if not search_result:
-            return result
-
-        # Parse tracks
-        if MediaType.TRACK in media_types and search_result.tracks:
-            for track in search_result.tracks.results[:limit]:
-                try:
-                    result.tracks = [*result.tracks, parse_track(self, track)]
-                except InvalidDataError as err:
-                    self.logger.debug("Error parsing track: %s", err)
-
-        # Parse albums — audiobooks are split into the audiobooks bucket via
-        # classify_album. Yandex-returned podcast albums are handled separately
-        # through the dedicated `.podcasts` node below. ``limit`` is applied per
-        # bucket AFTER classification — slicing first would drop audiobooks when
-        # the first ``limit`` results happen to be music albums (or vice versa).
-        want_album = MediaType.ALBUM in media_types
-        want_audiobook = MediaType.AUDIOBOOK in media_types
-        if (want_album or want_audiobook) and search_result.albums:
-            album_count = 0
-            audiobook_count = 0
-            for album in search_result.albums.results:
-                album_full = not want_album or album_count >= limit
-                audiobook_full = not want_audiobook or audiobook_count >= limit
-                if album_full and audiobook_full:
-                    break
-                kind = classify_album(album)
-                try:
-                    if kind == "audiobook" and want_audiobook and not audiobook_full:
-                        result.audiobooks = [
-                            *result.audiobooks,
-                            parse_audiobook(self, album),
-                        ]
-                        audiobook_count += 1
-                    elif kind == "music" and want_album and not album_full:
-                        result.albums = [*result.albums, parse_album(self, album)]
-                        album_count += 1
-                except InvalidDataError as err:
-                    self.logger.debug("Error parsing %s album: %s", kind, err)
-
-        # Parse artists
-        if MediaType.ARTIST in media_types and search_result.artists:
-            for artist in search_result.artists.results[:limit]:
-                try:
-                    result.artists = [*result.artists, parse_artist(self, artist)]
-                except InvalidDataError as err:
-                    self.logger.debug("Error parsing artist: %s", err)
-
-        # Parse playlists
-        if MediaType.PLAYLIST in media_types and search_result.playlists:
-            for playlist in search_result.playlists.results[:limit]:
-                try:
-                    result.playlists = [*result.playlists, parse_playlist(self, playlist)]
-                except InvalidDataError as err:
-                    self.logger.debug("Error parsing playlist: %s", err)
-
-        # Parse podcasts (Yandex returns them as albums under .podcasts)
-        podcasts_node = getattr(search_result, "podcasts", None)
-        if MediaType.PODCAST in media_types and podcasts_node:
-            for album in podcasts_node.results[:limit]:
-                try:
-                    result.podcasts = [*result.podcasts, parse_podcast(self, album)]
-                except InvalidDataError as err:
-                    self.logger.debug("Error parsing podcast: %s", err)
-
-        return result
-
-    # Get single items
-
-    @use_cache(3600 * 24 * 30, allow_expired_cache=True)
-    async def get_artist(self, prov_artist_id: str) -> Artist:
-        """
-        Get artist details by ID, enriched with description and listener stats.
-
-        :param prov_artist_id: The provider artist ID.
-        :return: Artist object.
-        :raises MediaNotFoundError: If artist not found.
-        """
-        artist, about = await asyncio.gather(
-            self.client.get_artist(prov_artist_id),
-            self.client.get_artist_about(prov_artist_id),
-        )
-        if not artist:
-            raise MediaNotFoundError(f"Artist {prov_artist_id} not found")
-        return parse_artist(self, artist, about=about)
-
-    @use_cache(3600 * 24 * 30, allow_expired_cache=True)
-    async def get_album(self, prov_album_id: str) -> Album:
-        """
-        Get album details by ID.
-
-        :param prov_album_id: The provider album ID.
-        :return: Album object.
-        :raises MediaNotFoundError: If album not found.
-        """
-        album = await self.client.get_album(prov_album_id)
-        if not album:
-            raise MediaNotFoundError(f"Album {prov_album_id} not found")
-        return parse_album(self, album)
-
-    @use_cache(3600 * 24, allow_expired_cache=True)
-    async def get_podcast(self, prov_podcast_id: str) -> Podcast:
-        """
-        Get podcast details by ID (backed by a Yandex album).
-
-        :param prov_podcast_id: The provider podcast (album) ID.
-        :return: Podcast object.
-        :raises MediaNotFoundError: If not found.
-        """
-        album = await self.client.get_album(prov_podcast_id)
-        if not album:
-            raise MediaNotFoundError(f"Podcast {prov_podcast_id} not found")
-        return parse_podcast(self, album)
-
-    async def get_podcast_episodes(self, prov_podcast_id: str) -> AsyncGenerator[PodcastEpisode]:
-        """Iterate podcast episodes for a given podcast (album) ID."""
-        album = await self.client.get_album_with_tracks(prov_podcast_id)
-        if not album:
-            raise MediaNotFoundError(f"Podcast {prov_podcast_id} not found")
-        podcast = parse_podcast(self, album)
-        position = 1
-        for disc in album.volumes or []:
-            for track_obj in disc:
-                try:
-                    yield parse_podcast_episode(self, track_obj, podcast, position=position)
-                except InvalidDataError as err:
-                    self.logger.debug("Error parsing podcast episode: %s", err)
-                position += 1
-
-    async def get_podcast_episode(self, prov_episode_id: str) -> PodcastEpisode:
-        """
-        Get a single podcast episode by ID.
-
-        The parent Podcast is reconstructed from the track's parent album. If
-        the album isn't present on the track, the episode cannot be converted
-        into a valid MA model and InvalidDataError is raised.
-        """
-        tracks = await self.client.get_tracks([prov_episode_id])
-        if not tracks:
-            raise MediaNotFoundError(f"Podcast episode {prov_episode_id} not found")
-        track_obj = tracks[0]
-        if not track_obj.albums:
-            raise InvalidDataError(
-                f"Podcast episode {prov_episode_id} is missing parent podcast album data"
-            )
-        podcast = parse_podcast(self, track_obj.albums[0])
-        return parse_podcast_episode(self, track_obj, podcast, position=0)
-
-    @use_cache(3600 * 24, allow_expired_cache=True)
-    async def get_audiobook(self, prov_audiobook_id: str) -> Audiobook:
-        """
-        Get audiobook details by ID, including chapters built from tracks.
-
-        :param prov_audiobook_id: The provider audiobook (album) ID.
-        :return: Audiobook object.
-        :raises MediaNotFoundError: If not found.
-        """
-        album = await self.client.get_album_with_tracks(prov_audiobook_id)
-        if not album:
-            raise MediaNotFoundError(f"Audiobook {prov_audiobook_id} not found")
-        audiobook = parse_audiobook(self, album)
-
-        chapters: list[MediaItemChapter] = []
-        start = 0.0
-        pos = 1
-        for disc in album.volumes or []:
-            for track_obj in disc:
-                dur_s = (track_obj.duration_ms or 0) / 1000.0
-                chapters.append(
-                    MediaItemChapter(
-                        position=pos,
-                        name=track_obj.title or f"Chapter {pos}",
-                        start=start,
-                        end=start + dur_s,
-                    )
-                )
-                start += dur_s
-                pos += 1
-        audiobook.metadata.chapters = chapters
-        audiobook.duration = int(start)
-        return audiobook
-
-    async def get_track(self, prov_track_id: str) -> Track:
-        """
-        Get track details by ID.
-
-        Supports composite item_id (track_id@station_id) for My Wave tracks;
-        only the track_id part is used for the API. Normalizes the ID before
-        caching to avoid duplicate cache entries.
-
-        :param prov_track_id: The provider track ID (or track_id@station_id).
-        :return: Track object.
-        :raises MediaNotFoundError: If track not found.
-        """
-        track_id, _ = _parse_radio_item_id(prov_track_id)
-        return await self._get_track_cached(track_id)
-
     @use_cache(3600 * 24 * 30, allow_expired_cache=True)
     async def _get_track_cached(self, track_id: str) -> Track:
         """
@@ -2280,59 +2935,6 @@ class YandexMusicProvider(MusicProvider):
         lyrics, lyrics_synced = await self.client.get_track_lyrics_from_track(yandex_track)
 
         return parse_track(self, yandex_track, lyrics=lyrics, lyrics_synced=lyrics_synced)
-
-    async def get_playlist(self, prov_playlist_id: str) -> Playlist:
-        """
-        Get playlist details by ID.
-
-        Supports virtual playlists MY_WAVE_PLAYLIST_ID (My Wave) and
-        LIKED_TRACKS_PLAYLIST_ID (Liked Tracks). Real playlists use format "owner_id:kind".
-
-        :param prov_playlist_id: The provider playlist ID (format: "owner_id:kind",
-            my_wave, or liked_tracks).
-        :return: Playlist object.
-        :raises MediaNotFoundError: If playlist not found.
-        """
-        # Virtual playlists - constructed locally (no API call); translation_key localizes
-        # the name for the connection locale at serialization.
-        if prov_playlist_id == MY_WAVE_PLAYLIST_ID:
-            return Playlist(
-                item_id=MY_WAVE_PLAYLIST_ID,
-                provider=self.instance_id,
-                name="My Wave",
-                translation_key=MY_WAVE_PLAYLIST_ID,
-                owner=get_canonical_provider_name(self),
-                provider_mappings={
-                    ProviderMapping(
-                        item_id=MY_WAVE_PLAYLIST_ID,
-                        provider_domain=self.domain,
-                        provider_instance=self.instance_id,
-                        is_unique=True,
-                    )
-                },
-                is_editable=False,
-            )
-
-        if prov_playlist_id == LIKED_TRACKS_PLAYLIST_ID:
-            return Playlist(
-                item_id=LIKED_TRACKS_PLAYLIST_ID,
-                provider=self.instance_id,
-                name="My Favorites",
-                translation_key=LIKED_TRACKS_PLAYLIST_ID,
-                owner=get_canonical_provider_name(self),
-                provider_mappings={
-                    ProviderMapping(
-                        item_id=LIKED_TRACKS_PLAYLIST_ID,
-                        provider_domain=self.domain,
-                        provider_instance=self.instance_id,
-                        is_unique=True,
-                    )
-                },
-                is_editable=False,
-            )
-
-        # Real playlists - use cached method
-        return await self._get_real_playlist(prov_playlist_id)
 
     @use_cache(3600 * 24 * 30, allow_expired_cache=True)
     async def _get_real_playlist(self, prov_playlist_id: str) -> Playlist:
@@ -2495,59 +3097,6 @@ class YandexMusicProvider(MusicProvider):
         self.logger.debug("Liked tracks: fetched %s, parsed %s", len(track_shorts), len(tracks))
         return tracks
 
-    # Get related items
-
-    @use_cache(3600 * 24 * 30, allow_expired_cache=True)
-    async def get_album_tracks(self, prov_album_id: str) -> list[Track]:
-        """
-        Get album tracks.
-
-        :param prov_album_id: The provider album ID.
-        :return: List of Track objects.
-        """
-        album = await self.client.get_album_with_tracks(prov_album_id)
-        if not album or not album.volumes:
-            return []
-
-        tracks = []
-        for volume_index, volume in enumerate(album.volumes):
-            for track_index, track in enumerate(volume):
-                try:
-                    parsed_track = parse_track(self, track)
-                    parsed_track.disc_number = volume_index + 1
-                    parsed_track.track_number = track_index + 1
-                    tracks.append(parsed_track)
-                except InvalidDataError as err:
-                    self.logger.debug("Error parsing album track: %s", err)
-        return tracks
-
-    async def get_similar_tracks(self, prov_track_id: str, limit: int = 25) -> list[Track]:
-        """
-        Get similar tracks, preferring pre-fetched wave tracks when available.
-
-        Split in two paths with different caching policies:
-
-        - **Wave-drain path** (the seed carries a station suffix and
-          ``wave.prefetched`` is non-empty). Uncached by design: it mutates
-          state, a cache hit would replay the same drained tracks forever and
-          the prefetch buffer would never advance.
-        - **Fallback path** (plain track_id, no active wave, or empty buffer).
-          Creates a per-seed rotor session under ``track:{id}`` and is cached
-          for 3 hours — this is pure and safe to memoise.
-
-        :param prov_track_id: Provider track ID (plain or track_id@station_id).
-        :param limit: Maximum number of tracks to return.
-        :return: List of similar Track objects.
-        """
-        track_id, station_key = _parse_radio_item_id(prov_track_id)
-
-        if station_key:
-            drained = await self._drain_prefetched_wave_tracks(station_key, limit)
-            if drained:
-                return drained
-
-        return await self._fetch_similar_tracks_for_seed(track_id, limit)
-
     async def _drain_prefetched_wave_tracks(self, station_key: str, limit: int) -> list[Track]:
         """
         Pop up to ``limit`` prefetched tracks off the wave state.
@@ -2598,80 +3147,6 @@ class YandexMusicProvider(MusicProvider):
             except InvalidDataError as err:
                 self.logger.debug("Error parsing similar track: %s", err)
         return similar_tracks
-
-    @use_cache(3600 * 3, allow_expired_cache=True)
-    async def get_similar_artists(self, prov_artist_id: str, limit: int = 25) -> list[Artist]:
-        """
-        Get artists similar to the given one via Yandex artists/similar endpoint.
-
-        :param prov_artist_id: Provider artist ID.
-        :param limit: Maximum number of artists to return.
-        :return: List of similar Artist objects.
-        """
-        yandex_artists = await self.client.get_similar_artists(prov_artist_id, limit=limit)
-        artists: list[Artist] = []
-        for ya in yandex_artists:
-            try:
-                artists.append(parse_artist(self, ya))
-            except InvalidDataError as err:
-                self.logger.debug("Error parsing similar artist: %s", err)
-        return artists
-
-    async def recommendations(self) -> list[RecommendationFolder]:
-        """
-        Get recommendations with multiple discovery folders.
-
-        Returns My Wave, Feed (Made for You), Chart, New Releases, and
-        New Playlists sections.
-
-        :return: List of recommendation folders.
-        """
-        folders: list[RecommendationFolder] = []
-
-        folder = await self._get_my_wave_recommendations()
-        if folder:
-            folders.append(folder)
-
-        folder = await self._get_feed_recommendations()
-        if folder:
-            folders.append(folder)
-
-        folder = await self._get_chart_recommendations()
-        if folder:
-            folders.append(folder)
-
-        folder = await self._get_new_releases_recommendations()
-        if folder:
-            folders.append(folder)
-
-        folder = await self._get_new_playlists_recommendations()
-        if folder:
-            folders.append(folder)
-
-        # Picks & Mixes recommendations
-        folder = await self._get_top_picks_recommendations()
-        if folder:
-            folders.append(folder)
-
-        # Mood mix: select tag outside cache so rotation actually works
-        mood_tag = await self._pick_random_tag_for_category("mood")
-        if mood_tag:
-            folder = await self._get_mood_mix_recommendations(mood_tag)
-            if folder:
-                folders.append(folder)
-
-        # Activity mix: select tag outside cache so rotation actually works
-        activity_tag = await self._pick_random_tag_for_category("activity")
-        if activity_tag:
-            folder = await self._get_activity_mix_recommendations(activity_tag)
-            if folder:
-                folders.append(folder)
-
-        folder = await self._get_seasonal_mix_recommendations()
-        if folder:
-            folders.append(folder)
-
-        return folders
 
     @use_cache(600, allow_expired_cache=True)
     async def _get_my_wave_recommendations(self) -> RecommendationFolder | None:
@@ -3029,155 +3504,6 @@ class YandexMusicProvider(MusicProvider):
             icon="mdi-weather-sunny",
         )
 
-    @use_cache(3600 * 3, allow_expired_cache=True)
-    async def get_playlist_tracks(self, prov_playlist_id: str, page: int = 0) -> list[Track]:
-        """
-        Get playlist tracks.
-
-        :param prov_playlist_id: The provider playlist ID (format: "owner_id:kind",
-            my_wave, or liked_tracks).
-        :param page: Page number for pagination.
-        :return: List of Track objects.
-        """
-        self.logger.debug(
-            "get_playlist_tracks called: prov_playlist_id=%s, page=%s", prov_playlist_id, page
-        )
-
-        if prov_playlist_id == MY_WAVE_PLAYLIST_ID:
-            self.logger.debug("Fetching My Wave tracks")
-            return await self._get_my_wave_playlist_tracks(page)
-
-        if prov_playlist_id == LIKED_TRACKS_PLAYLIST_ID:
-            self.logger.debug("Fetching Liked Tracks for virtual playlist")
-            result = await self._get_liked_tracks_playlist_tracks(page)
-            self.logger.debug("Liked Tracks playlist returned %s tracks", len(result))
-            return result
-
-        # Yandex Music API returns all playlist tracks in one call (no server-side pagination).
-        # Return empty list for page > 0 so the controller pagination loop terminates.
-        if page > 0:
-            return []
-
-        # Parse the playlist ID (format: owner_id:kind)
-        if PLAYLIST_ID_SPLITTER in prov_playlist_id:
-            owner_id, kind = prov_playlist_id.split(PLAYLIST_ID_SPLITTER, 1)
-        else:
-            owner_id = str(self.client.user_id)
-            kind = prov_playlist_id
-
-        playlist = await self.client.get_playlist(owner_id, kind)
-        if not playlist:
-            return []
-
-        # API sometimes returns playlist without tracks; fetch them explicitly if needed
-        tracks_list = playlist.tracks or []
-        track_count = getattr(playlist, "track_count", None) or 0
-        if not tracks_list and track_count > 0:
-            self.logger.debug(
-                "Playlist %s/%s: track_count=%s but no tracks in response, "
-                "calling fetch_tracks_async",
-                owner_id,
-                kind,
-                track_count,
-            )
-            try:
-                tracks_list = await playlist.fetch_tracks_async()
-            except Exception as err:
-                self.logger.warning("fetch_tracks_async failed for %s/%s: %s", owner_id, kind, err)
-            if not tracks_list:
-                raise ResourceTemporarilyUnavailable(
-                    "Playlist tracks not available; try again later"
-                )
-
-        if not tracks_list:
-            return []
-
-        # Yandex returns TrackShort objects, we need to fetch full track info
-        track_ids = [
-            str(track.track_id) if hasattr(track, "track_id") else str(track.id)
-            for track in tracks_list
-            if track
-        ]
-        if not track_ids:
-            return []
-
-        # Fetch full track details in batches to avoid timeouts
-        batch_size = TRACK_BATCH_SIZE
-        full_tracks = []
-        for i in range(0, len(track_ids), batch_size):
-            batch = track_ids[i : i + batch_size]
-            batch_result = await self.client.get_tracks(batch)
-            if not batch_result:
-                # Skip this batch but keep going — the terminal guard below
-                # raises if every batch comes back empty. Aborting on a single
-                # empty batch threw away tracks already fetched from earlier
-                # batches and forced a full retry hours later (under the
-                # @use_cache TTL above).
-                self.logger.warning(
-                    "Empty batch %s-%s for playlist %s, skipping",
-                    i,
-                    i + len(batch) - 1,
-                    prov_playlist_id,
-                )
-                continue
-            full_tracks.extend(batch_result)
-
-        if track_ids and not full_tracks:
-            raise ResourceTemporarilyUnavailable("Failed to load track details; try again later")
-
-        tracks = []
-        for track in full_tracks:
-            try:
-                tracks.append(parse_track(self, track))
-            except InvalidDataError as err:
-                self.logger.debug("Error parsing playlist track: %s", err)
-        return tracks
-
-    @use_cache(3600 * 24 * 7, allow_expired_cache=True)
-    async def get_artist_albums(self, prov_artist_id: str) -> list[Album]:
-        """
-        Get artist's albums.
-
-        :param prov_artist_id: The provider artist ID.
-        :return: List of Album objects.
-        """
-        albums = await self.client.get_artist_albums(prov_artist_id)
-        result = []
-        for album in albums:
-            try:
-                result.append(parse_album(self, album))
-            except InvalidDataError as err:
-                self.logger.debug("Error parsing artist album: %s", err)
-        return result
-
-    @use_cache(3600 * 24 * 7, allow_expired_cache=True)
-    async def get_artist_toptracks(self, prov_artist_id: str) -> list[Track]:
-        """
-        Get artist's top tracks.
-
-        :param prov_artist_id: The provider artist ID.
-        :return: List of Track objects.
-        """
-        tracks = await self.client.get_artist_tracks(prov_artist_id)
-        result = []
-        for track in tracks:
-            try:
-                result.append(parse_track(self, track))
-            except InvalidDataError as err:
-                self.logger.debug("Error parsing artist track: %s", err)
-        return result
-
-    # Library methods
-
-    async def get_library_artists(self) -> AsyncGenerator[Artist]:
-        """Retrieve library artists from Yandex Music."""
-        artists = await self.client.get_liked_artists()
-        for artist in artists:
-            try:
-                yield parse_artist(self, artist)
-            except InvalidDataError as err:
-                self.logger.debug("Error parsing library artist: %s", err)
-
     async def _get_liked_albums_cached(self, ttl: float = 30.0) -> list[YandexAlbum]:
         """
         Return liked albums with a short in-process TTL cache + lock.
@@ -3198,165 +3524,12 @@ class YandexMusicProvider(MusicProvider):
             self._liked_albums_cache = (now, albums)
             return albums
 
-    async def get_library_albums(self) -> AsyncGenerator[Album]:
-        """
-        Retrieve library albums from Yandex Music.
-
-        Excludes entries classified as podcasts or audiobooks so they don't
-        duplicate into the Albums library view.
-        """
-        for album in await self._get_liked_albums_cached():
-            if classify_album(album) != "music":
-                continue
-            try:
-                yield parse_album(self, album)
-            except InvalidDataError as err:
-                self.logger.debug("Error parsing library album: %s", err)
-
-    async def get_library_podcasts(self) -> AsyncGenerator[Podcast]:
-        """Retrieve library podcasts from Yandex Music (filtered liked albums)."""
-        for album in await self._get_liked_albums_cached():
-            if classify_album(album) != "podcast":
-                continue
-            try:
-                yield parse_podcast(self, album)
-            except InvalidDataError as err:
-                self.logger.debug("Error parsing library podcast: %s", err)
-
-    async def get_library_audiobooks(self) -> AsyncGenerator[Audiobook]:
-        """Retrieve library audiobooks from Yandex Music (filtered liked albums)."""
-        for album in await self._get_liked_albums_cached():
-            if classify_album(album) != "audiobook":
-                continue
-            try:
-                yield parse_audiobook(self, album)
-            except InvalidDataError as err:
-                self.logger.debug("Error parsing library audiobook: %s", err)
-
-    async def get_library_tracks(self) -> AsyncGenerator[Track]:
-        """Retrieve library tracks from Yandex Music."""
-        track_shorts = await self.client.get_liked_tracks()
-        if not track_shorts:
-            return
-
-        # Fetch full track details in batches
-        track_ids = [str(ts.track_id) for ts in track_shorts if ts.track_id]
-        batch_size = TRACK_BATCH_SIZE
-        for i in range(0, len(track_ids), batch_size):
-            batch_ids = track_ids[i : i + batch_size]
-            full_tracks = await self.client.get_tracks(batch_ids)
-            for track in full_tracks:
-                try:
-                    yield parse_track(self, track)
-                except InvalidDataError as err:
-                    self.logger.debug("Error parsing library track: %s", err)
-
-    async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
-        """
-        Retrieve library playlists from Yandex Music.
-
-        Includes virtual playlists (My Wave and Liked Tracks if enabled), user-created playlists,
-        and user-liked editorial playlists (returned by a separate API endpoint).
-        """
-        yield await self.get_playlist(MY_WAVE_PLAYLIST_ID)
-        yield await self.get_playlist(LIKED_TRACKS_PLAYLIST_ID)
-        seen_ids: set[str] = set()
-        # User-created playlists
-        playlists = await self.client.get_user_playlists()
-        for playlist in playlists:
-            try:
-                parsed = parse_playlist(self, playlist)
-                seen_ids.add(parsed.item_id)
-                yield parsed
-            except InvalidDataError as err:
-                self.logger.debug("Error parsing library playlist: %s", err)
-        # User-liked editorial playlists (not in users_playlists_list)
-        liked_playlists = await self.client.get_liked_playlists()
-        for playlist in liked_playlists:
-            try:
-                parsed = parse_playlist(self, playlist)
-                if parsed.item_id not in seen_ids:
-                    yield parsed
-            except InvalidDataError as err:
-                self.logger.debug("Error parsing liked playlist: %s", err)
-
-    # Library edit methods
-
-    async def library_add(self, item: MediaItemType) -> bool:
-        """
-        Add item to library.
-
-        For tracks carrying a wave station context in the item_id (e.g. when
-        the user adds a My Wave track to favourites during playback), also
-        fires a rotor ``like`` feedback on the active session so the wave
-        algorithm biases toward similar tracks immediately.
-
-        :param item: The media item to add.
-        :return: True if successful.
-        """
-        prov_item_id = self._get_provider_item_id(item)
-        if not prov_item_id:
-            return False
-        track_id, station_key = _parse_radio_item_id(prov_item_id)
-
-        if item.media_type == MediaType.TRACK:
-            ok = await self.client.like_track(track_id)
-            if ok and station_key:
-                wave = self._wave_states.get(station_key)
-                if wave and wave.session_id:
-                    await self._send_wave_feedback(wave, station_key, "like", track_id=track_id)
-            return ok
-        if item.media_type in (MediaType.ALBUM, MediaType.PODCAST, MediaType.AUDIOBOOK):
-            return await self.client.like_album(prov_item_id)
-        if item.media_type == MediaType.ARTIST:
-            return await self.client.like_artist(prov_item_id)
-        return False
-
-    async def library_remove(self, prov_item_id: str, media_type: MediaType) -> bool:
-        """
-        Remove item from library.
-
-        :param prov_item_id: The provider item ID (may be track_id@station_id for tracks).
-        :param media_type: The media type.
-        :return: True if successful.
-        """
-        track_id, _ = _parse_radio_item_id(prov_item_id)
-        if media_type == MediaType.TRACK:
-            return await self.client.unlike_track(track_id)
-        if media_type in (MediaType.ALBUM, MediaType.PODCAST, MediaType.AUDIOBOOK):
-            return await self.client.unlike_album(prov_item_id)
-        if media_type == MediaType.ARTIST:
-            return await self.client.unlike_artist(prov_item_id)
-        return False
-
     def _get_provider_item_id(self, item: MediaItemType) -> str | None:
         """Get provider item ID from media item."""
         for mapping in item.provider_mappings:
             if mapping.provider_instance == self.instance_id:
                 return mapping.item_id
         return item.item_id if item.provider == self.instance_id else None
-
-    # Streaming
-
-    async def get_stream_details(
-        self, item_id: str, media_type: MediaType = MediaType.TRACK
-    ) -> StreamDetails:
-        """
-        Get stream details for a track, podcast episode, or audiobook.
-
-        A podcast episode is a track underneath the Yandex API, so it flows
-        through the same per-track streaming path. An audiobook is an album
-        with multiple tracks (chapters) — returned as a CUSTOM stream whose
-        generator concatenates each chapter's bytes in order.
-
-        :param item_id: The track / episode ID (or track_id@station_id for My Wave),
-            or the audiobook (album) ID when ``media_type`` is AUDIOBOOK.
-        :param media_type: The media type.
-        :return: StreamDetails for the item.
-        """
-        if media_type == MediaType.AUDIOBOOK:
-            return await self._get_audiobook_stream_details(item_id)
-        return await self.streaming.get_stream_details(item_id)
 
     async def _get_audiobook_stream_details(self, audiobook_id: str) -> StreamDetails:
         """
@@ -3398,28 +3571,6 @@ class YandexMusicProvider(MusicProvider):
             can_seek=True,
             allow_seek=True,
         )
-
-    async def get_audio_stream(
-        self, streamdetails: StreamDetails, seek_position: int = 0
-    ) -> AsyncGenerator[bytes]:
-        """
-        Return the audio stream for the provider item.
-
-        For tracks and podcast episodes, streams via windowed Range requests
-        (raw or AES-CTR encrypted). For audiobooks, iterates chapters: each
-        chapter's bytes are streamed through the per-track path and concatenated.
-
-        :param streamdetails: Stream details with URL and optional decryption key.
-        :param seek_position: Seek position in seconds (handled by provider for raw transport).
-        :return: Async generator yielding audio chunks.
-        """
-        data = streamdetails.data if isinstance(streamdetails.data, dict) else None
-        if streamdetails.media_type == MediaType.AUDIOBOOK and data and "chapter_ids" in data:
-            async for chunk in self._stream_audiobook_chapters(data, seek_position):
-                yield chunk
-            return
-        async for chunk in self.streaming.get_audio_stream(streamdetails, seek_position):
-            yield chunk
 
     def _resolve_audiobook_seek(
         self, chapter_durations_ms: list[int], seek_position: int, n_chapters: int
@@ -3543,157 +3694,6 @@ class YandexMusicProvider(MusicProvider):
             raise MediaNotFoundError(
                 "Unable to stream audiobook: no playable chapters found"
             ) from last_error
-
-    async def get_rotor_station_tracks(
-        self, station_id: str, queue: str | int | None = None
-    ) -> tuple[list[Any], str | None]:
-        """
-        Fetch tracks from a rotor station using the session API.
-
-        Public surface — pinned by the ynison plugin
-        (`YandexMusicProviderLike.get_rotor_station_tracks`). The
-        ``(tracks, batch_id)`` return contract is kept for that caller even
-        though batch_id is now a session-scoped identifier.
-
-        Routes to ``_fetch_rotor_session_batch`` so the wave session state
-        (`session_id`, seen tracks, prefetch) is shared with our own Browse /
-        on_played / on_streamed flows. ``queue`` is the most recently played
-        track ID the external caller observed — we record it as the
-        pagination cursor before calling through.
-
-        :param station_id: Rotor station ID (e.g. "user:onyourwave",
-            "genre:rock", "mood:calm", "track:1234").
-        :param queue: Last-played track ID for pagination. Ignored on the
-            very first call (no session yet) but still recorded.
-        :return: Tuple of (list of yandex tracks, batch_id or None).
-        """
-        wave = self._get_wave_state(station_id)
-        # Cursor update + batch fetch run under the station's lock, matching
-        # the discipline in browse / recommendations / prefetch. Without it,
-        # ynison replenish racing with a concurrent MA browse could interleave
-        # last_track_id writes and leave session_id / batch_id out of sync.
-        async with wave.lock:
-            if queue is not None:
-                wave.last_track_id = str(queue)
-            return await self._fetch_rotor_session_batch(wave, station_id)
-
-    def get_quality(self) -> str:
-        """Return the configured audio quality tier (e.g. 'balanced', 'superb')."""
-        quality = str(self.config.get_value(CONF_QUALITY) or QUALITY_BALANCED).strip().lower()
-        if quality == "lossless":
-            quality = QUALITY_SUPERB
-        return quality
-
-    async def resolve_image(self, path: str) -> str | bytes:
-        """
-        Resolve wave cover image with background color fill for transparent PNGs.
-
-        If the image URL has an associated background color (stored in _wave_bg_colors),
-        downloads the PNG from Yandex CDN and composites it on a solid color background
-        using Pillow, returning JPEG bytes. Falls back to the original URL on any error.
-
-        :param path: Image URL (may include #rrggbb fragment used as cache key).
-        :return: Composited JPEG bytes, or original path string as fallback.
-        """
-        bg_color = self._wave_bg_colors.get(path)
-        if not bg_color:
-            return path
-
-        # Strip the #color fragment before fetching the actual image
-        fetch_url = path.split("#", maxsplit=1)[0] if "#" in path else path
-        try:
-            async with self.mass.http_session.get(fetch_url) as resp:
-                resp.raise_for_status()
-                raw = await resp.read()
-        except Exception as err:
-            self.logger.debug("Failed to fetch wave cover %s: %s", fetch_url, err)
-            return fetch_url
-
-        def _composite() -> bytes:
-            bg_clean = bg_color.lstrip("#")
-            try:
-                r = int(bg_clean[0:2], 16)
-                g = int(bg_clean[2:4], 16)
-                b = int(bg_clean[4:6], 16)
-            except ValueError, IndexError:
-                return raw
-            fg = PilImage.open(BytesIO(raw)).convert("RGBA")
-            bg = PilImage.new("RGBA", fg.size, (r, g, b, 255))
-            bg.paste(fg, mask=fg)
-            out = BytesIO()
-            bg.convert("RGB").save(out, "JPEG", quality=92)
-            return out.getvalue()
-
-        try:
-            return await asyncio.to_thread(_composite)
-        except Exception as err:
-            self.logger.debug("Wave cover composite failed for %s: %s", fetch_url, err)
-            return fetch_url
-
-    async def on_played(
-        self,
-        media_type: MediaType,
-        prov_item_id: str,
-        fully_played: bool,
-        position: int,
-        media_item: MediaItemType,
-        is_playing: bool = False,
-    ) -> None:
-        """
-        Report periodic playback updates.
-
-        - Audiobooks: persist chapter progress via play_audio so Yandex's
-          own clients resume at the right point.
-        - Wave tracks: send rotor ``trackStarted`` while actively playing and
-          kick off a background prefetch so DSTM refill serves wave-curated
-          tracks with no extra round-trip. DSTM itself is the user's toggle —
-          the provider does not flip it.
-
-        Generic track history reporting is not attempted here — the only
-        known channel Yandex writes into ``/handlers/music-history`` is a
-        long-lived Ynison WebSocket session, which lives in the sibling
-        yandex_ynison plugin. Regular tracks played through MA are therefore
-        invisible to Listening History unless that plugin is also active.
-        """
-        if media_type == MediaType.AUDIOBOOK:
-            await self._report_audiobook_progress(prov_item_id, position)
-            return
-        if media_type != MediaType.TRACK:
-            return
-        _, station_id = _parse_radio_item_id(prov_item_id)
-        if station_id and is_playing:
-            track_id, _ = _parse_radio_item_id(prov_item_id)
-            wave = self._wave_states.get(station_id) or self._get_wave_state(station_id)
-            await self._send_wave_feedback(wave, station_id, "trackStarted", track_id=track_id)
-            self.mass.create_task(self._prefetch_rotor_session(station_id))
-
-    async def on_streamed(self, streamdetails: StreamDetails) -> None:
-        """
-        Report stream completion to Yandex.
-
-        - Audiobooks: a final ``play_audio`` with the absolute stream
-          position so the last listening point is preserved across Yandex
-          clients. Cleans up session state even when ``data`` was stripped.
-        - Wave tracks (composite item_id carries a station suffix): a rotor
-          ``trackFinished`` or ``skip`` event with the actual seconds streamed
-          so Yandex can improve recommendations.
-        """
-        data = streamdetails.data if isinstance(streamdetails.data, dict) else None
-        if streamdetails.media_type == MediaType.AUDIOBOOK:
-            await self._report_audiobook_final(streamdetails, data or {})
-            return
-        if streamdetails.media_type != MediaType.TRACK:
-            return
-        track_id, station_id = _parse_radio_item_id(streamdetails.item_id)
-        if not station_id:
-            return
-        seconds = int(streamdetails.seconds_streamed or 0)
-        duration = int(streamdetails.duration or 0)
-        feedback_type = "trackFinished" if duration and seconds >= max(0, duration - 10) else "skip"
-        wave = self._wave_states.get(station_id) or self._get_wave_state(station_id)
-        await self._send_wave_feedback(
-            wave, station_id, feedback_type, track_id=track_id, total_played_seconds=seconds
-        )
 
     def _audiobook_progress_point(
         self,

--- a/provider/streaming.py
+++ b/provider/streaming.py
@@ -70,12 +70,6 @@ class YandexMusicStreamingManager:
         self.mass = provider.mass
         self.logger = provider.logger
 
-    def _track_id_from_item_id(self, item_id: str) -> str:
-        """Extract API track ID from item_id (may be track_id@station_id for My Wave)."""
-        if RADIO_TRACK_ID_SEP in item_id:
-            return item_id.split(RADIO_TRACK_ID_SEP, 1)[0]
-        return item_id
-
     async def get_stream_details(self, item_id: str) -> StreamDetails:
         """
         Get stream details for a track.
@@ -222,6 +216,133 @@ class YandexMusicStreamingManager:
             allow_seek=True,
             expiration=50,  # download-info direct links expire after ~60s
         )
+
+    async def get_audio_stream(
+        self, streamdetails: StreamDetails, seek_position: int = 0
+    ) -> AsyncGenerator[bytes]:
+        """
+        Return the audio stream via windowed Range requests.
+
+        Handles both raw (direct) and encraw (AES-CTR encrypted) transports.
+        Downloads in windowed Range requests of _RANGE_WINDOW bytes each to prevent
+        Yandex CDN from dropping slow-consumer TCP connections.
+
+        On connection drop: flat short backoff (0.5s/1.0s/2.0s).
+        On read stall: exponential backoff (2s/4s/8s).
+        On URL expiry (HTTP 4xx): re-fetches URL and resumes from bytes_yielded.
+        Retry counter resets after each successful window.
+
+        :param streamdetails: Stream details with URL (and optional decryption key).
+        :param seek_position: Seek offset in seconds for raw transport (0 = from start).
+        :return: Async generator yielding audio bytes.
+        """
+        data = streamdetails.data
+        is_encrypted, key_bytes = self._validate_encryption_key(data)
+        initial_byte_offset = self._calculate_seek_offset(data, seek_position, is_encrypted)
+
+        max_retries = 6
+        bytes_yielded = initial_byte_offset
+        attempt = 0
+        retry_delay: float = 0.0
+
+        while True:
+            if attempt > 0:
+                await asyncio.sleep(retry_delay)
+
+            block_start = (
+                (bytes_yielded // _AES_BLOCK_SIZE) * _AES_BLOCK_SIZE
+                if is_encrypted
+                else bytes_yielded
+            )
+            window_end = block_start + _RANGE_WINDOW - 1
+
+            try:
+                async with self.mass.http_session.get(
+                    data["url"],
+                    headers={"Range": f"bytes={block_start}-{window_end}"},
+                    timeout=_STREAM_TIMEOUT,
+                ) as response:
+                    if response.status in (401, 403, 410):
+                        new_key = await self._handle_expired_url(
+                            streamdetails,
+                            response.status,
+                            bytes_yielded,
+                            attempt,
+                            max_retries,
+                        )
+                        if is_encrypted:
+                            key_bytes = new_key
+                        attempt += 1
+                        retry_delay = 0.0
+                        continue
+                    try:
+                        response.raise_for_status()
+                    except Exception as err:
+                        # Do not embed err.__str__ — aiohttp's ClientResponseError
+                        # includes the signed CDN URL, which carries an expiring
+                        # signature that should not reach logs or the frontend.
+                        raise MediaNotFoundError(
+                            f"Failed to fetch stream: HTTP {response.status}"
+                        ) from err
+
+                    bytes_before = bytes_yielded
+                    if is_encrypted:
+                        if key_bytes is None:
+                            raise MediaNotFoundError("Missing decryption key")
+                        block_skip = bytes_before - block_start
+                        async for chunk in self._decrypt_response_stream(
+                            response,
+                            key_bytes,
+                            _AES_BLOCK_SIZE,
+                            bytes_yielded,
+                        ):
+                            bytes_yielded += len(chunk)
+                            yield chunk
+                    else:
+                        range_ignored = response.status == 200 and block_start > 0
+                        block_skip = bytes_before if range_ignored else 0
+                        async for chunk in self._iter_raw_response(
+                            response,
+                            bytes_before,
+                            block_start,
+                        ):
+                            bytes_yielded += len(chunk)
+                            yield chunk
+
+                    received = (bytes_yielded - bytes_before) + block_skip
+                    if response.status == 200 or received < _RANGE_WINDOW:
+                        return
+                    if self._is_content_range_eof(response.headers, window_end):
+                        return
+                    attempt = 0
+                    retry_delay = 0.0
+
+            except asyncio.CancelledError:
+                raise
+            except (ClientPayloadError, ServerDisconnectedError) as err:
+                attempt, retry_delay = self._handle_stream_error(
+                    err,
+                    attempt,
+                    max_retries,
+                    bytes_yielded,
+                    _TCP_DROP_DELAYS,
+                    "dropped",
+                )
+            except TimeoutError as err:
+                attempt, retry_delay = self._handle_stream_error(
+                    err,
+                    attempt,
+                    max_retries,
+                    bytes_yielded,
+                    _STALL_DELAYS,
+                    "stalled",
+                )
+
+    def _track_id_from_item_id(self, item_id: str) -> str:
+        """Extract API track ID from item_id (may be track_id@station_id for My Wave)."""
+        if RADIO_TRACK_ID_SEP in item_id:
+            return item_id.split(RADIO_TRACK_ID_SEP, 1)[0]
+        return item_id
 
     def _select_best_quality(
         self, download_infos: list[Any], preferred_quality: str | None
@@ -751,124 +872,3 @@ class YandexMusicStreamingManager:
             bit_rate,
         )
         return byte_offset
-
-    async def get_audio_stream(
-        self, streamdetails: StreamDetails, seek_position: int = 0
-    ) -> AsyncGenerator[bytes]:
-        """
-        Return the audio stream via windowed Range requests.
-
-        Handles both raw (direct) and encraw (AES-CTR encrypted) transports.
-        Downloads in windowed Range requests of _RANGE_WINDOW bytes each to prevent
-        Yandex CDN from dropping slow-consumer TCP connections.
-
-        On connection drop: flat short backoff (0.5s/1.0s/2.0s).
-        On read stall: exponential backoff (2s/4s/8s).
-        On URL expiry (HTTP 4xx): re-fetches URL and resumes from bytes_yielded.
-        Retry counter resets after each successful window.
-
-        :param streamdetails: Stream details with URL (and optional decryption key).
-        :param seek_position: Seek offset in seconds for raw transport (0 = from start).
-        :return: Async generator yielding audio bytes.
-        """
-        data = streamdetails.data
-        is_encrypted, key_bytes = self._validate_encryption_key(data)
-        initial_byte_offset = self._calculate_seek_offset(data, seek_position, is_encrypted)
-
-        max_retries = 6
-        bytes_yielded = initial_byte_offset
-        attempt = 0
-        retry_delay: float = 0.0
-
-        while True:
-            if attempt > 0:
-                await asyncio.sleep(retry_delay)
-
-            block_start = (
-                (bytes_yielded // _AES_BLOCK_SIZE) * _AES_BLOCK_SIZE
-                if is_encrypted
-                else bytes_yielded
-            )
-            window_end = block_start + _RANGE_WINDOW - 1
-
-            try:
-                async with self.mass.http_session.get(
-                    data["url"],
-                    headers={"Range": f"bytes={block_start}-{window_end}"},
-                    timeout=_STREAM_TIMEOUT,
-                ) as response:
-                    if response.status in (401, 403, 410):
-                        new_key = await self._handle_expired_url(
-                            streamdetails,
-                            response.status,
-                            bytes_yielded,
-                            attempt,
-                            max_retries,
-                        )
-                        if is_encrypted:
-                            key_bytes = new_key
-                        attempt += 1
-                        retry_delay = 0.0
-                        continue
-                    try:
-                        response.raise_for_status()
-                    except Exception as err:
-                        # Do not embed err.__str__ — aiohttp's ClientResponseError
-                        # includes the signed CDN URL, which carries an expiring
-                        # signature that should not reach logs or the frontend.
-                        raise MediaNotFoundError(
-                            f"Failed to fetch stream: HTTP {response.status}"
-                        ) from err
-
-                    bytes_before = bytes_yielded
-                    if is_encrypted:
-                        if key_bytes is None:
-                            raise MediaNotFoundError("Missing decryption key")
-                        block_skip = bytes_before - block_start
-                        async for chunk in self._decrypt_response_stream(
-                            response,
-                            key_bytes,
-                            _AES_BLOCK_SIZE,
-                            bytes_yielded,
-                        ):
-                            bytes_yielded += len(chunk)
-                            yield chunk
-                    else:
-                        range_ignored = response.status == 200 and block_start > 0
-                        block_skip = bytes_before if range_ignored else 0
-                        async for chunk in self._iter_raw_response(
-                            response,
-                            bytes_before,
-                            block_start,
-                        ):
-                            bytes_yielded += len(chunk)
-                            yield chunk
-
-                    received = (bytes_yielded - bytes_before) + block_skip
-                    if response.status == 200 or received < _RANGE_WINDOW:
-                        return
-                    if self._is_content_range_eof(response.headers, window_end):
-                        return
-                    attempt = 0
-                    retry_delay = 0.0
-
-            except asyncio.CancelledError:
-                raise
-            except (ClientPayloadError, ServerDisconnectedError) as err:
-                attempt, retry_delay = self._handle_stream_error(
-                    err,
-                    attempt,
-                    max_retries,
-                    bytes_yielded,
-                    _TCP_DROP_DELAYS,
-                    "dropped",
-                )
-            except TimeoutError as err:
-                attempt, retry_delay = self._handle_stream_error(
-                    err,
-                    attempt,
-                    max_retries,
-                    bytes_yielded,
-                    _STALL_DELAYS,
-                    "stalled",
-                )


### PR DESCRIPTION
## Why

The `check-method-order` pre-commit hook landed with the wrapper sync in #214 (vendored mirror of the upstream music-assistant/server AGENTS.md rule: private methods live at the bottom of each class). `dev` violates it massively, which is why the Lint & Type Check job went red on #218 — that PR's own diff (setup scripts) was innocent; it just was the first branch to run CI with the new hook.

## What

Stable partition of the methods in the three offending classes:

- `YandexMusicClient` (api_client) — 23 private methods moved below the 50 public ones
- `YandexMusicProvider` (provider) — 57 private methods moved below the 37 public ones
- `YandexMusicStreamingManager` (streaming) — 15 private methods moved below the 3 public ones

Public/dunder methods keep their original relative order; private methods keep theirs. Comments and decorators travel with their method.

## Verification

- Pure move: an AST comparison against the previous revision confirms every method (body + decorators) and all module-level code is identical — only the order inside class bodies changed (diff is symmetric: 3260+/3260−).
- `pre-commit run --all-files` — all hooks pass, including `check-method-order` and mypy.
- `uv run pytest` — 393 passed, 7 snapshots passed.

No changelog entry: internal code reorder with no user-observable change. No spec: `refactor:` is exempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)