### PR TITLE
fix: upstream dev lint parity (strings.json config texts, ruff 0.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- fix(tests): `_MockResponse.__aenter__` returns `Self` (PYI034), per the upstream dev ruff rules.
+- style: ruff 0.15 safe autofixes matching the upstream dev lint rules.
+
 ## [3.8.3] - 2026-07-13
 
 ### Changed

--- a/provider/auth.py
+++ b/provider/auth.py
@@ -1,4 +1,5 @@
-"""Yandex Music authentication flows.
+"""
+Yandex Music authentication flows.
 
 Thin provider-side wrappers over the shared Music Assistant auth layer in
 ``ya_passport_auth.ma`` (device-code page, QR flow, token maintenance with
@@ -62,7 +63,8 @@ PAGE_CONFIG = DevicePageConfig(
 
 
 async def perform_device_auth(mass: MusicAssistant, session_id: str) -> tuple[str, str, str]:
-    """Perform Yandex OAuth Device Flow and return credential tokens.
+    """
+    Perform Yandex OAuth Device Flow and return credential tokens.
 
     Asks Yandex for a device code, presents it to the user via an
     MA-hosted intermediate page, then polls until the user confirms or the
@@ -82,7 +84,8 @@ async def perform_device_auth(mass: MusicAssistant, session_id: str) -> tuple[st
 
 
 async def perform_qr_auth(mass: MusicAssistant, session_id: str) -> tuple[str, str]:
-    """Perform full QR authentication flow.
+    """
+    Perform full QR authentication flow.
 
     Opens a QR code popup via MA frontend, polls for scan confirmation,
     then returns tokens as plain strings for MA config storage.
@@ -97,7 +100,8 @@ async def perform_qr_auth(mass: MusicAssistant, session_id: str) -> tuple[str, s
 
 
 async def refresh_music_token(x_token: SecretStr) -> SecretStr:
-    """Exchange an x_token for a fresh music-scoped OAuth token.
+    """
+    Exchange an x_token for a fresh music-scoped OAuth token.
 
     Distinguishes transient Passport failures (network/rate limiting) from
     credential-invalid errors: only the latter raise ``LoginFailed``, so
@@ -109,7 +113,8 @@ async def refresh_music_token(x_token: SecretStr) -> SecretStr:
 async def refresh_credentials_via_passport(
     x_token: SecretStr, refresh_token: SecretStr
 ) -> Credentials:
-    """Silently re-issue the full credential triple using a refresh token.
+    """
+    Silently re-issue the full credential triple using a refresh token.
 
     Only available for accounts authenticated via the Device Flow (QR login
     does not yield a ``refresh_token``). Rotates both ``x_token`` and
@@ -120,7 +125,8 @@ async def refresh_credentials_via_passport(
 
 
 async def validate_x_token(x_token: SecretStr) -> bool:
-    """Return True if *x_token* is still accepted by Yandex Passport.
+    """
+    Return True if *x_token* is still accepted by Yandex Passport.
 
     A ``False`` return signals "rejected by Passport" — a terminal credential
     failure. Transient network or rate-limit errors are re-raised so callers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,7 +79,8 @@ def provider_dir() -> Path:
 
 
 class ProviderStub:
-    """Minimal provider-like object for parser tests (no Mock).
+    """
+    Minimal provider-like object for parser tests (no Mock).
 
     Provides the minimal interface needed by parse_* functions.
     """
@@ -114,7 +115,8 @@ class ConfigStub:
 
 
 class StreamingProviderStub:
-    """Minimal provider stub for streaming tests (no Mock).
+    """
+    Minimal provider stub for streaming tests (no Mock).
 
     Provides the minimal interface needed by YandexMusicStreamingManager.
     """
@@ -163,7 +165,8 @@ class TrackingLogger:
 
 
 class StreamingProviderStubWithTracking:
-    """Provider stub with tracking logger for assertions.
+    """
+    Provider stub with tracking logger for assertions.
 
     Use this when you need to verify logging behavior.
     """

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -37,7 +37,8 @@ from music_assistant.providers.yandex_music.constants import (
 
 
 def _make_client() -> tuple[YandexMusicClient, mock.AsyncMock]:
-    """Create a YandexMusicClient with a mocked underlying ClientAsync.
+    """
+    Create a YandexMusicClient with a mocked underlying ClientAsync.
 
     Also mocks connect() so that _reconnect() restores the mock client
     instead of trying to create a real connection.
@@ -238,7 +239,8 @@ def _patch_get_tracks(client: YandexMusicClient, tracks: list[object]) -> mock.A
 
 
 def _call_args(m: mock.AsyncMock) -> tuple[tuple[Any, ...], Mapping[str, Any]]:
-    """Return (args, kwargs) from the most recent await on ``m``.
+    """
+    Return (args, kwargs) from the most recent await on ``m``.
 
     Raises AssertionError when the mock was never awaited — intentionally
     surfacing missed setup rather than letting mypy's `None is not iterable`
@@ -435,7 +437,8 @@ async def test_rotor_session_feedback_like_uses_trackid_without_seconds() -> Non
 
 
 async def test_rotor_session_request_maps_unauthorized_to_login_failed() -> None:
-    """Expired/invalid token during /rotor/session/* surfaces as LoginFailed.
+    """
+    Expired/invalid token during /rotor/session/* surfaces as LoginFailed.
 
     Without this mapping the raw ``UnauthorizedError`` from the MarshalX
     client would bubble up through browse / play paths and crash the
@@ -583,7 +586,8 @@ async def test_get_artist_about_returns_none_on_network_error() -> None:
 
 
 def test_lrc_regex_matches_valid_synced_lyrics() -> None:
-    """LRC regex matches valid synced lyrics with proper format [mm:ss.xx].
+    """
+    LRC regex matches valid synced lyrics with proper format [mm:ss.xx].
 
     Uses re.search (no ^ anchor) matching the implementation in api_client.py,
     which intentionally allows timestamps anywhere in the text so that LRC
@@ -755,7 +759,8 @@ async def test_get_dashboard_stations_returns_personalized_stations() -> None:
 
 
 async def test_get_track_file_info_parses_camelcase_download_info() -> None:
-    """get_track_file_info parses the v3-style camelCase ``downloadInfo`` key.
+    """
+    get_track_file_info parses the v3-style camelCase ``downloadInfo`` key.
 
     The yandex-music v3 client no longer recursively normalises camelCase keys
     inside ``Response.result``. The raw JSON for /get-file-info comes back as
@@ -987,7 +992,8 @@ async def test_bypass_throttler_bypasses_block() -> None:
 
 
 async def test_captcha_during_bypass_still_engages_block() -> None:
-    """Captcha received during a BYPASS_THROTTLER call must still quarantine the kind.
+    """
+    Captcha received during a BYPASS_THROTTLER call must still quarantine the kind.
 
     Stream URL refresh runs under BYPASS_THROTTLER to keep an in-flight track
     alive — but if Yandex returns smart-captcha on that very refresh, we DO
@@ -1088,7 +1094,8 @@ async def test_file_info_cache_hit_skips_network() -> None:
 
 
 async def test_file_info_cache_separates_entries_by_codecs() -> None:
-    """Different codec preference lists must NOT share a cache slot.
+    """
+    Different codec preference lists must NOT share a cache slot.
 
     Yandex picks the codec (and download URL) based on the codec order, so a
     cached response for codecs="flac-mp4,flac" must not be reused when the
@@ -1215,7 +1222,8 @@ async def test_file_info_cache_lru_eviction(monkeypatch: pytest.MonkeyPatch) -> 
 
 
 async def test_check_block_runs_again_after_throttler_acquire() -> None:
-    """A concurrent request that passed the pre-check must bail after acquire().
+    """
+    A concurrent request that passed the pre-check must bail after acquire().
 
     Without the post-acquire re-check, requests already queued in the
     throttler when another request engages the cooldown would proceed to
@@ -1241,7 +1249,8 @@ async def test_check_block_runs_again_after_throttler_acquire() -> None:
 
 
 async def test_rotor_feedback_no_retry_propagates_429_to_engage_block() -> None:
-    """Rotor session feedback (with_retry=False) must propagate 429s.
+    """
+    Rotor session feedback (with_retry=False) must propagate 429s.
 
     The inner `_do` swallows ordinary NetworkErrors for fire-and-forget
     paths, but a captcha 429 must reach `_call_no_retry` so the rotor
@@ -1272,7 +1281,8 @@ async def test_rotor_feedback_no_retry_propagates_429_to_engage_block() -> None:
 
 
 async def test_retry_path_classifies_captcha_after_reconnect() -> None:
-    """A captcha 429 on the reconnect-retry attempt must engage the block.
+    """
+    A captcha 429 on the reconnect-retry attempt must engage the block.
 
     Without classification on the retry, the raw NetworkError propagates
     with the full HTML body and the kind cooldown is never set.
@@ -1303,7 +1313,8 @@ async def test_retry_path_classifies_captcha_after_reconnect() -> None:
 
 
 async def test_retry_path_re_checks_block_before_retry() -> None:
-    """A retry after reconnect must re-check the per-kind block.
+    """
+    A retry after reconnect must re-check the per-kind block.
 
     Another concurrent task may engage the cooldown while the reconnect is
     in flight; without a re-check, the retry would still hit Yandex during
@@ -1329,7 +1340,8 @@ async def test_retry_path_re_checks_block_before_retry() -> None:
 
 
 async def test_file_info_cache_hit_blocked_during_cooldown() -> None:
-    """A populated cache must not be served while the file_info kind is blocked.
+    """
+    A populated cache must not be served while the file_info kind is blocked.
 
     Otherwise the streaming layer would happily replay a pre-cooldown URL
     while Yandex is actively rate-limiting our IP/account, defeating the
@@ -1356,7 +1368,8 @@ async def test_file_info_cache_hit_blocked_during_cooldown() -> None:
 
 
 async def test_bypass_refresh_replaces_cached_entry() -> None:
-    """BYPASS_THROTTLER refresh must overwrite the existing cache entry.
+    """
+    BYPASS_THROTTLER refresh must overwrite the existing cache entry.
 
     Otherwise the next non-bypass caller keeps receiving the old URL until
     the TTL expires, even though refresh has just proven that entry stale.
@@ -1395,7 +1408,8 @@ async def test_bypass_refresh_replaces_cached_entry() -> None:
 
 
 async def test_file_info_cache_invalidated_on_unauthorized() -> None:
-    """UnauthorizedError on a refresh must clear the cached entry for the track.
+    """
+    UnauthorizedError on a refresh must clear the cached entry for the track.
 
     Otherwise post-re-auth callers could be served a URL tied to the
     expired session.
@@ -1845,7 +1859,8 @@ async def test_get_artist_tracks_propagates_captcha_rtu() -> None:
 
 
 async def test_jitter_skipped_under_bypass_throttler() -> None:
-    """Stream URL refresh paths run under BYPASS_THROTTLER — jitter must not fire.
+    """
+    Stream URL refresh paths run under BYPASS_THROTTLER — jitter must not fire.
 
     The helper sits inside the ``if not BYPASS_THROTTLER.get():`` block in
     both _call_with_retry and _call_no_retry. If a future refactor lifts
@@ -1884,7 +1899,8 @@ async def test_jitter_skipped_under_bypass_throttler() -> None:
 
 
 async def test_search_swallows_bad_request_as_empty_result() -> None:
-    """A 4xx from Yandex search is terminal — return None, do not signal retry.
+    """
+    A 4xx from Yandex search is terminal — return None, do not signal retry.
 
     Wrapping ``BadRequestError`` as ``ResourceTemporarilyUnavailable`` tells
     Music Assistant the request can be retried, which reproduces the same
@@ -1923,7 +1939,8 @@ async def test_get_liked_albums_swallows_bad_request_as_empty_list() -> None:
 
 
 async def test_get_liked_tracks_sort_survives_naive_timestamp() -> None:
-    """Sorting must not crash when ``TrackShort.timestamp`` is timezone-naive.
+    """
+    Sorting must not crash when ``TrackShort.timestamp`` is timezone-naive.
 
     The upstream ``yandex-music`` library is inconsistent about tz on
     ``TrackShort.timestamp``. Comparing a naive ``datetime`` against the
@@ -1951,7 +1968,8 @@ async def test_get_liked_tracks_sort_survives_naive_timestamp() -> None:
 
 
 async def test_call_with_retry_reacquires_throttler_on_reconnect() -> None:
-    """The reconnect-retry path must consume a throttler token too.
+    """
+    The reconnect-retry path must consume a throttler token too.
 
     Skipping ``throttler.acquire()`` on the second attempt doubles the
     effective request rate during connection flap — exactly the conditions
@@ -1974,7 +1992,8 @@ async def test_call_with_retry_reacquires_throttler_on_reconnect() -> None:
 
 
 async def test_jitter_skipped_when_kind_already_blocked() -> None:
-    """A blocked kind must fast-fail BEFORE the jitter sleep.
+    """
+    A blocked kind must fast-fail BEFORE the jitter sleep.
 
     Order contract in _call_with_retry: _check_block -> jitter -> acquire ->
     _check_block. The pre-check raises RTU immediately when the kind is
@@ -2006,7 +2025,8 @@ async def test_jitter_skipped_when_kind_already_blocked() -> None:
 
 
 async def test_parallel_same_endpoint_calls_serialize() -> None:
-    """Parallel calls to the same endpoint must run one-at-a-time.
+    """
+    Parallel calls to the same endpoint must run one-at-a-time.
 
     Yandex's edge treats concurrent requests to the same URL family as a
     scraper signature and trips captcha within ~460 ms. The per-endpoint
@@ -2043,7 +2063,8 @@ async def test_parallel_same_endpoint_calls_serialize() -> None:
 
 
 async def test_restrictive_mode_caps_global_concurrency() -> None:
-    """Restrictive mode caps total in-flight requests to ``RESTRICTIVE_GLOBAL_CONCURRENCY``.
+    """
+    Restrictive mode caps total in-flight requests to ``RESTRICTIVE_GLOBAL_CONCURRENCY``.
 
     Yandex's edge enforces a per-token concurrency limit on datacenter /
     VPN IPs (empirically ~6 simultaneous before captcha). The
@@ -2114,7 +2135,8 @@ async def test_restrictive_mode_caps_global_concurrency() -> None:
 
 
 async def test_parallel_different_endpoints_run_concurrently() -> None:
-    """Calls to different endpoint methods must NOT block each other.
+    """
+    Calls to different endpoint methods must NOT block each other.
 
     The per-endpoint lock is keyed on the calling method's qualname, so
     parallel calls to distinct YandexMusicClient methods proceed in

--- a/tests/test_audiobook_progress.py
+++ b/tests/test_audiobook_progress.py
@@ -267,7 +267,8 @@ async def test_on_streamed_audiobook_without_data_still_cleans_up(
 async def test_on_streamed_audiobook_branch_taken_even_without_chapter_data(
     provider_mock: Mock,
 ) -> None:
-    """AUDIOBOOK stream without chapter_ids still routes to audiobook cleanup.
+    """
+    AUDIOBOOK stream without chapter_ids still routes to audiobook cleanup.
 
     Previously the gate required ``"chapter_ids" in data`` and fell through
     to the radio path when data was missing, leaving caches stale.

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -49,7 +49,8 @@ def skip_grace_sleep() -> Generator[mock.AsyncMock]:
 async def drain_teardown_tasks(
     skip_grace_sleep: mock.AsyncMock,  # noqa: ARG001 — orders teardown before the patch exits
 ) -> AsyncGenerator[None]:
-    """Settle deferred route-teardown tasks before the grace-sleep patch exits.
+    """
+    Settle deferred route-teardown tasks before the grace-sleep patch exits.
 
     Cancels leftovers instead of awaiting them so a test that failed before
     releasing a hung grace sleep cannot deadlock the whole run.
@@ -256,7 +257,8 @@ async def test_perform_device_auth_serves_intermediate_page_and_cleans_up() -> N
 
 
 async def test_perform_device_auth_status_endpoint_reports_done_after_success() -> None:
-    """The status endpoint reports state=done after the device flow completes.
+    """
+    The status endpoint reports state=done after the device flow completes.
 
     Without this the popup window (opened via target=_blank) has no signal to
     close itself after the user confirms the code.
@@ -288,7 +290,8 @@ async def test_perform_device_auth_status_endpoint_reports_done_after_success() 
 async def test_perform_device_auth_returns_without_grace_delay(
     skip_grace_sleep: mock.AsyncMock,
 ) -> None:
-    """The flow returns as soon as auth completes — the grace period must not block it.
+    """
+    The flow returns as soon as auth completes — the grace period must not block it.
 
     The grace sleep is made to hang forever: the caller must still get its
     tokens immediately, while the routes stay registered until the deferred
@@ -327,7 +330,8 @@ async def test_perform_device_auth_returns_without_grace_delay(
 async def test_perform_device_auth_immediate_retry_reuses_session_path(
     skip_grace_sleep: mock.AsyncMock,
 ) -> None:
-    """A retry with the same session id must succeed while teardown is still pending.
+    """
+    A retry with the same session id must succeed while teardown is still pending.
 
     The MA frontend can reuse the config-flow session id for a rapid second
     login attempt; the previous attempt's routes (awaiting their grace-period
@@ -362,7 +366,8 @@ async def test_perform_device_auth_immediate_retry_reuses_session_path(
 
 
 async def test_route_teardown_attempts_every_path_despite_errors() -> None:
-    """A failing unregister for one route must not skip the remaining routes.
+    """
+    A failing unregister for one route must not skip the remaining routes.
 
     Teardown runs in a detached task (e.g. during MA shutdown the webserver
     may already be gone) — one failure must not leak the other route or
@@ -388,7 +393,8 @@ async def test_route_teardown_attempts_every_path_despite_errors() -> None:
 
 
 async def test_device_code_page_countdown_reflects_elapsed_time() -> None:
-    """The countdown shows the time actually left, not the full code lifetime.
+    """
+    The countdown shows the time actually left, not the full code lifetime.
 
     The popup can open (or be reloaded) long after the code was issued; the
     page must be rendered with the remaining seconds at request time.
@@ -413,7 +419,8 @@ async def test_device_code_page_countdown_reflects_elapsed_time() -> None:
 async def test_perform_device_auth_status_reports_failure_reason(
     exc: Exception, expected_reason: str, expected_match: str
 ) -> None:
-    """When poll fails, the status endpoint reports failed plus a machine-readable reason.
+    """
+    When poll fails, the status endpoint reports failed plus a machine-readable reason.
 
     The page uses the reason to tell the user what to do next — an expired
     code and a rejected login require different actions.
@@ -453,7 +460,8 @@ async def test_perform_device_auth_status_reports_failure_reason(
 
 
 async def test_perform_device_auth_does_not_mark_cancellation_as_failure() -> None:
-    """CancelledError must propagate without marking state as 'failed'.
+    """
+    CancelledError must propagate without marking state as 'failed'.
 
     Routes must still be torn down eventually so a cancelled login doesn't
     leak webserver routes.
@@ -611,7 +619,8 @@ def _make_page_mass(locale: object = None) -> mock.MagicMock:
 
 
 async def test_device_code_page_copy_targets_code_block() -> None:
-    """The code block itself is the copy target; no standalone copy button.
+    """
+    The code block itself is the copy target; no standalone copy button.
 
     ``document.execCommand`` must be present as the fallback because the
     Clipboard API is unavailable on plain-HTTP MA deployments.
@@ -875,7 +884,8 @@ async def test_validate_x_token_invalid_returns_false() -> None:
     ids=["network", "rate_limited"],
 )
 async def test_validate_x_token_transient_error_propagates(exc: Exception) -> None:
-    """Transient Passport failures must not masquerade as "token invalid".
+    """
+    Transient Passport failures must not masquerade as "token invalid".
 
     A network blip or 429 should not cause callers to clear the stored
     credential — re-raise so the caller can distinguish the two.

--- a/tests/test_browse_collection.py
+++ b/tests/test_browse_collection.py
@@ -103,7 +103,8 @@ async def test_collection_hides_audiobooks_folder_when_feature_disabled() -> Non
 
 @pytest.mark.asyncio
 async def test_collection_folders_carry_authored_translation_keys() -> None:
-    """Collection folders localize via translation keys authored in strings.json.
+    """
+    Collection folders localize via translation keys authored in strings.json.
 
     Localization happens at API serialization (per connection locale), so
     the provider must emit an English fallback name plus a key that exists

--- a/tests/test_browse_pins_history.py
+++ b/tests/test_browse_pins_history.py
@@ -134,7 +134,8 @@ async def test_browse_history_returns_empty_when_no_history(
 
 
 def _hist_item(track_id: int) -> object:
-    """Build a history entry the way MarshalX actually returns it.
+    """
+    Build a history entry the way MarshalX actually returns it.
 
     `data.item_id` is a dict containing track_id, album_id, etc.; `full_model`
     is not populated by the live API. Callers batch-resolve via get_tracks.

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -16,7 +16,8 @@ if TYPE_CHECKING:
 
 
 async def test_get_config_entries_label_prompts_save_after_auth() -> None:
-    """After a successful login action, the label must warn about the Save step.
+    """
+    After a successful login action, the label must warn about the Save step.
 
     Tokens live only in the dialog values until the user hits Save — a missed
     Save silently discards the whole login.

--- a/tests/test_localization.py
+++ b/tests/test_localization.py
@@ -77,7 +77,8 @@ async def test_config_entries_have_no_hardcoded_labels() -> None:
 
 
 async def test_quality_options_use_value_first_signature() -> None:
-    """Quality options store the QUALITY_* constants as their values.
+    """
+    Quality options store the QUALITY_* constants as their values.
 
     Guards against the legacy (title, value) positional order, which the
     current models interpret as value=title — silently corrupting the
@@ -96,7 +97,8 @@ async def test_quality_options_use_value_first_signature() -> None:
 
 
 async def test_auth_status_label_localized_via_translation_key() -> None:
-    """The dynamic auth status label carries a per-state translation key.
+    """
+    The dynamic auth status label carries a per-state translation key.
 
     The post-login "click Save" warning (spec 0002) must be authored in
     strings.json so Lokalise localizes it like everything else.
@@ -116,7 +118,8 @@ async def test_auth_status_label_localized_via_translation_key() -> None:
 
 
 async def test_strings_json_authors_device_page_keys() -> None:
-    """Every device-code page string is authored under page.device_code.
+    """
+    Every device-code page string is authored under page.device_code.
 
     The HTML ``lang`` attribute is presentation plumbing, not a
     translatable string, so it stays code-side.

--- a/tests/test_my_wave.py
+++ b/tests/test_my_wave.py
@@ -172,7 +172,8 @@ async def test_fetch_rotor_session_batch_works_with_track_seed_station() -> None
 
 @pytest.mark.asyncio
 async def test_get_rotor_station_tracks_wrapper_delegates_to_session_batch() -> None:
-    """Ynison-facing wrapper routes through _fetch_rotor_session_batch.
+    """
+    Ynison-facing wrapper routes through _fetch_rotor_session_batch.
 
     This keeps ynison on the session API (long-lived radioSessionId, shared
     wave state, prefetch) without any code change on its side — the
@@ -415,7 +416,8 @@ async def test_library_add_track_without_station_skips_rotor_feedback() -> None:
 
 
 def _preset_config(values: dict[str, str]) -> Mock:
-    """Build a config stub whose get_value looks up keys in the given dict.
+    """
+    Build a config stub whose get_value looks up keys in the given dict.
 
     Non-listed keys return None, matching MA's ``ConfigValueType | None`` contract.
     """
@@ -482,7 +484,8 @@ def test_get_user_wave_presets_skips_items_without_name() -> None:
 
 
 def test_get_user_wave_presets_drops_whitespace_only_values() -> None:
-    """Whitespace-only dropdown values (e.g. hand-edited JSON) are treated as empty.
+    """
+    Whitespace-only dropdown values (e.g. hand-edited JSON) are treated as empty.
 
     Yandex rejects ``settingDiversity:`` with a 4xx, so the parser must not
     propagate such values. Valid values are also stripped to their canonical
@@ -693,7 +696,8 @@ async def test_send_wave_feedback_uses_session_api_when_session_id_present() -> 
 
 @pytest.mark.asyncio
 async def test_send_wave_feedback_skips_silently_without_session() -> None:
-    """Without ``wave.session_id`` the call is a silent no-op returning False.
+    """
+    Without ``wave.session_id`` the call is a silent no-op returning False.
 
     The legacy stations-based feedback endpoint is gone (returns 404), so we
     can't usefully fall back there. Callers treat the False result as

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,4 +1,5 @@
-"""Unit tests for YandexMusicProvider (provider.py).
+"""
+Unit tests for YandexMusicProvider (provider.py).
 
 These tests construct a partial provider instance via ``__new__`` (no
 ``__init__``), attach the attributes the method-under-test reads, and
@@ -21,7 +22,8 @@ from music_assistant.providers.yandex_music.provider import YandexMusicProvider
 
 
 def _make_provider() -> tuple[YandexMusicProvider, mock.AsyncMock]:
-    """Return a YandexMusicProvider with a mocked Yandex API client.
+    """
+    Return a YandexMusicProvider with a mocked Yandex API client.
 
     The provider is constructed without calling ``__init__`` so the upstream
     base-class init does not run. ``client`` is a property over ``_client``,
@@ -41,7 +43,8 @@ def _make_provider() -> tuple[YandexMusicProvider, mock.AsyncMock]:
 
 
 async def test_get_playlist_tracks_continues_on_empty_batch() -> None:
-    """An empty batch mid-load must skip-and-continue, not discard prior batches.
+    """
+    An empty batch mid-load must skip-and-continue, not discard prior batches.
 
     With ``TRACK_BATCH_SIZE`` of 50, a 150-track playlist resolves in 3 batches.
     If batch 2 transiently returns an empty list, the previous behavior raised
@@ -116,7 +119,8 @@ async def test_get_playlist_tracks_raises_only_when_every_batch_is_empty() -> No
 
 
 async def test_unload_clears_all_per_session_caches() -> None:
-    """unload() must drop every state dict mirrored in handle_async_init().
+    """
+    unload() must drop every state dict mirrored in handle_async_init().
 
     Without this, stale ``asyncio.Lock`` instances bound to the previous
     event loop survive a provider reload and break wave-session locking

--- a/tests/test_recommendations.py
+++ b/tests/test_recommendations.py
@@ -949,7 +949,8 @@ def _real_yandex_track() -> Any:
 
 @pytest.mark.asyncio
 async def test_get_my_wave_recommendations_with_real_parser(provider_mock: Mock) -> None:
-    """End-to-end: real ``_parse_my_wave_track`` against a real Yandex track fixture.
+    """
+    End-to-end: real ``_parse_my_wave_track`` against a real Yandex track fixture.
 
     Mocking ``_parse_my_wave_track`` directly (as the success/duplicate/error
     tests above do) cannot catch a regression where ``parse_track`` returns a

--- a/tests/test_search_audiobooks.py
+++ b/tests/test_search_audiobooks.py
@@ -103,7 +103,8 @@ async def test_search_album_and_audiobook_split(provider_mock: Mock) -> None:
 async def test_search_audiobook_not_dropped_by_limit_when_music_dominates(
     provider_mock: Mock,
 ) -> None:
-    """Limit applied per bucket after classification, not before.
+    """
+    Limit applied per bucket after classification, not before.
 
     Audiobooks tail-listed by Yandex must still appear when top ``limit``
     results are music albums.

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import unittest.mock
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Self
 
 import pytest
 from aiohttp import ClientPayloadError, ServerDisconnectedError
@@ -95,7 +95,8 @@ def test_select_best_quality_balanced_falls_back_to_highest(
 def test_select_best_quality_legacy_lossless_alias_returns_flac(
     streaming_manager: YandexMusicStreamingManager,
 ) -> None:
-    """Legacy stored value 'lossless' (pre-Superb rename) still maps to FLAC.
+    """
+    Legacy stored value 'lossless' (pre-Superb rename) still maps to FLAC.
 
     Current UI writes ``superb``; older configs may still hold the literal
     ``lossless`` string. The selector must treat the two as synonyms.
@@ -451,7 +452,7 @@ class _MockResponse:
         if self._error is not None:
             raise self._error
 
-    async def __aenter__(self) -> _MockResponse:
+    async def __aenter__(self) -> Self:
         return self
 
     async def __aexit__(self, *args: object) -> None:
@@ -511,7 +512,8 @@ async def test_get_audio_stream_http_error_does_not_leak_signed_url(
     streaming_manager: YandexMusicStreamingManager,
     streaming_provider_stub: StreamingProviderStub,
 ) -> None:
-    """Re-raised stream error must not include the signed CDN URL.
+    """
+    Re-raised stream error must not include the signed CDN URL.
 
     ``aiohttp``'s ``ClientResponseError.__str__`` embeds the request URL, which
     for Yandex audio responses carries an expiring signature in the query
@@ -789,7 +791,8 @@ async def test_get_audio_stream_exact_window_boundary(
     streaming_manager: YandexMusicStreamingManager,
     streaming_provider_stub: StreamingProviderStub,
 ) -> None:
-    """File whose size is an exact multiple of _RANGE_WINDOW does not trigger a 416 error.
+    """
+    File whose size is an exact multiple of _RANGE_WINDOW does not trigger a 416 error.
 
     Without the Content-Range EOF guard the loop would request the next window after
     receiving exactly _RANGE_WINDOW bytes in a 206 response, which would result in a
@@ -831,7 +834,8 @@ async def test_get_audio_stream_continues_after_non_block_boundary_drop(
     streaming_manager: YandexMusicStreamingManager,
     streaming_provider_stub: StreamingProviderStub,
 ) -> None:
-    """TCP drop at a non-AES-block boundary must not cause premature EOF on reconnect.
+    """
+    TCP drop at a non-AES-block boundary must not cause premature EOF on reconnect.
 
     Scenario (patched window = 32 bytes = 2 AES blocks, 50-byte file):
     - Window 1 (bytes=0-31) drops at byte 17 (not on a 16-byte AES boundary).
@@ -1133,7 +1137,8 @@ def _attach_get_track(
 async def test_get_stream_details_happy_path_uses_get_file_info(
     streaming_manager: YandexMusicStreamingManager,
 ) -> None:
-    """When ``get_track_file_info`` returns a URL, build StreamDetails directly.
+    """
+    When ``get_track_file_info`` returns a URL, build StreamDetails directly.
 
     The fast path skips the legacy ``download-info`` fallback entirely.
     """
@@ -1165,7 +1170,8 @@ async def test_get_stream_details_happy_path_uses_get_file_info(
 async def test_get_stream_details_falls_back_to_download_info_when_file_info_empty(
     streaming_manager: YandexMusicStreamingManager,
 ) -> None:
-    """When ``get_track_file_info`` returns ``None``, use the download-info path.
+    """
+    When ``get_track_file_info`` returns ``None``, use the download-info path.
 
     The fallback uses ``StreamType.HTTP`` with the direct CDN link from the
     legacy ``/tracks/{id}/download-info`` endpoint.


### PR DESCRIPTION
## Description

Fixes `_MockResponse.__aenter__` in `tests/test_streaming.py` to return `Self` (PYI034 — no safe autofix exists).

Also includes the ruff 0.15 **safe** autofixes (D213 docstring style etc.) that provider CI would otherwise auto-commit on the next push once the new dev-mirrored lint config lands.

**Context:** trudenboy/ma-provider-tools#119 switches provider CI to full lint parity with `music-assistant/server` **dev** (dev-synced ruff rules, ruff 0.15, and a new *Upstream repo checks* gate running upstream's `check_*` pre-commit scripts). This PR fixes everything that gate and rule set flag in this repo, so CI stays green after the rollout — these were previously silent failures that would only surface on the first upstream PR.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] CI/Infrastructure
- [x] Refactoring

## Testing

- [ ] Tests pass locally (`uv run pytest`) — not run locally (needs full MA env); PR CI runs the suite
- [x] Lint passes — ruff 0.15 with the upstream-dev config: 0 findings; simulated the new *Upstream repo checks* gate against a fresh `music-assistant/server@dev` clone on Python 3.14: all checks green; `py3.14 -m compileall` clean
- [ ] New/changed code is covered by tests — no behavior change intended (texts move to strings.json)

## Checklist

- [x] Documentation updated if behavior changed (CHANGELOG entry added)
- [x] No secrets or credentials committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)