### PR TITLE
reverse-sync: Load recommendation rows on demand (#4487)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.8.4] - 2026-07-30
 
+### Added
+
+- Recommendation rows now load on demand when selected, avoiding unnecessary Yandex requests during discovery.
+
 ### Changed
 
 - Parser compatibility baselines now cover the `artist_entity_type` and `life_span` metadata fields introduced by current Music Assistant models.

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -997,61 +997,103 @@ class YandexMusicProvider(MusicProvider):
                 self.logger.debug("Error parsing similar artist: %s", err)
         return artists
 
-    async def recommendations(self) -> list[RecommendationFolder]:
-        """
-        Get recommendations with multiple discovery folders.
+    async def get_recommendations(self) -> list[RecommendationFolder]:
+        """Return static recommendation row descriptors without backend calls."""
+        seasonal_tag = TAG_SEASONAL_MAP.get(utc().month, "autumn")
+        seasonal_name = seasonal_tag.title()
+        return [
+            RecommendationFolder(
+                item_id=MY_WAVE_PLAYLIST_ID,
+                provider=self.instance_id,
+                name="My Wave",
+                translation_key=MY_WAVE_PLAYLIST_ID,
+                icon="mdi-waveform",
+            ),
+            RecommendationFolder(
+                item_id="feed",
+                provider=self.instance_id,
+                name="Made for You",
+                translation_key="feed",
+                icon="mdi-account-music",
+            ),
+            RecommendationFolder(
+                item_id="chart",
+                provider=self.instance_id,
+                name="Chart",
+                translation_key="chart",
+                icon="mdi-chart-line",
+            ),
+            RecommendationFolder(
+                item_id="new_releases",
+                provider=self.instance_id,
+                name="New Releases",
+                translation_key="new_releases",
+                icon="mdi-new-box",
+            ),
+            RecommendationFolder(
+                item_id="new_playlists",
+                provider=self.instance_id,
+                name="New Playlists",
+                translation_key="new_playlists",
+                icon="mdi-playlist-star",
+            ),
+            RecommendationFolder(
+                item_id="top_picks",
+                provider=self.instance_id,
+                name="Top Picks",
+                translation_key="top_picks",
+                icon="mdi-star",
+            ),
+            RecommendationFolder(
+                item_id="mood_mix",
+                provider=self.instance_id,
+                name="Mood Mix",
+                translation_key="mood_mix",
+                icon="mdi-emoticon-outline",
+            ),
+            RecommendationFolder(
+                item_id="activity_mix",
+                provider=self.instance_id,
+                name="Activity Mix",
+                translation_key="activity_mix",
+                icon="mdi-run",
+            ),
+            RecommendationFolder(
+                item_id="seasonal_mix",
+                provider=self.instance_id,
+                name=f"Seasonal: {seasonal_name}",
+                translation_key="seasonal_mix",
+                translation_params=[seasonal_name],
+                icon="mdi-weather-sunny",
+            ),
+        ]
 
-        Returns My Wave, Feed (Made for You), Chart, New Releases, and
-        New Playlists sections.
-
-        :return: List of recommendation folders.
-        """
-        folders: list[RecommendationFolder] = []
-
-        folder = await self._get_my_wave_recommendations()
-        if folder:
-            folders.append(folder)
-
-        folder = await self._get_feed_recommendations()
-        if folder:
-            folders.append(folder)
-
-        folder = await self._get_chart_recommendations()
-        if folder:
-            folders.append(folder)
-
-        folder = await self._get_new_releases_recommendations()
-        if folder:
-            folders.append(folder)
-
-        folder = await self._get_new_playlists_recommendations()
-        if folder:
-            folders.append(folder)
-
-        # Picks & Mixes recommendations
-        folder = await self._get_top_picks_recommendations()
-        if folder:
-            folders.append(folder)
-
-        # Mood mix: select tag outside cache so rotation actually works
-        mood_tag = await self._pick_random_tag_for_category("mood")
-        if mood_tag:
-            folder = await self._get_mood_mix_recommendations(mood_tag)
-            if folder:
-                folders.append(folder)
-
-        # Activity mix: select tag outside cache so rotation actually works
-        activity_tag = await self._pick_random_tag_for_category("activity")
-        if activity_tag:
-            folder = await self._get_activity_mix_recommendations(activity_tag)
-            if folder:
-                folders.append(folder)
-
-        folder = await self._get_seasonal_mix_recommendations()
-        if folder:
-            folders.append(folder)
-
-        return folders
+    async def get_recommendation_items(
+        self, item_id: str
+    ) -> UniqueList[MediaItemType | ItemMapping | BrowseFolder]:
+        """Load items for one recommendation row."""
+        folder: RecommendationFolder | None = None
+        if item_id == MY_WAVE_PLAYLIST_ID:
+            folder = await self._get_my_wave_recommendations()
+        elif item_id == "feed":
+            folder = await self._get_feed_recommendations()
+        elif item_id == "chart":
+            folder = await self._get_chart_recommendations()
+        elif item_id == "new_releases":
+            folder = await self._get_new_releases_recommendations()
+        elif item_id == "new_playlists":
+            folder = await self._get_new_playlists_recommendations()
+        elif item_id == "top_picks":
+            folder = await self._get_top_picks_recommendations()
+        elif item_id == "mood_mix":
+            if tag := await self._pick_random_tag_for_category("mood"):
+                folder = await self._get_mood_mix_recommendations(tag)
+        elif item_id == "activity_mix":
+            if tag := await self._pick_random_tag_for_category("activity"):
+                folder = await self._get_activity_mix_recommendations(tag)
+        elif item_id == "seasonal_mix":
+            folder = await self._get_seasonal_mix_recommendations()
+        return folder.items if folder else UniqueList()
 
     @use_cache(3600 * 3, allow_expired_cache=True)
     async def get_playlist_tracks(self, prov_playlist_id: str, page: int = 0) -> list[Track]:

--- a/provider/strings.json
+++ b/provider/strings.json
@@ -318,10 +318,10 @@
         "name": "Top Picks"
       },
       "mood_mix": {
-        "name": "Mood Mix: {0}"
+        "name": "Mood Mix"
       },
       "activity_mix": {
-        "name": "Activity Mix: {0}"
+        "name": "Activity Mix"
       },
       "seasonal_mix": {
         "name": "Seasonal: {0}"

--- a/specs/done/reverse-sync-pr4487.md
+++ b/specs/done/reverse-sync-pr4487.md
@@ -1,0 +1,22 @@
+# Reverse-sync: upstream PR #4487
+
+Ported from music-assistant/server#4487 into `yandex_music`.
+
+## Summary
+
+Adopt Music Assistant's lazy recommendation-row API. Discovery now returns
+nine ordered, empty descriptors without contacting Yandex; the new item
+dispatcher loads only the row selected by the client.
+
+## Acceptance criteria
+
+- `get_recommendations` returns nine stable row IDs in the authored order.
+- Descriptor discovery performs no Yandex backend calls.
+- `get_recommendation_items` loads only the requested row helper.
+- Mood and Activity choose their tag outside cached item helpers.
+- Empty, unavailable, and unknown rows return an empty `UniqueList`.
+- Existing recommendation parsers, caches, and error handling remain intact.
+
+## Test plan
+
+Run `tests/test_recommendations.py`, then the full repository quality gate.

--- a/tests/test_recommendations.py
+++ b/tests/test_recommendations.py
@@ -17,6 +17,7 @@ from music_assistant_models.media_items import (
     Playlist,
     RecommendationFolder,
     Track,
+    UniqueList,
 )
 from yandex_music import Track as YandexTrack
 
@@ -830,7 +831,7 @@ async def test_get_recommendation_items_chart_triggers_only_chart_fetch(
         item_id="chart",
         provider=provider_mock.instance_id,
         name="Chart",
-        items=[track],
+        items=UniqueList([track]),
     )
     provider_mock._get_chart_recommendations = AsyncMock(return_value=folder)
 
@@ -851,7 +852,7 @@ async def test_get_recommendation_items_picks_tag_outside_cached_helper(
         item_id="mood_mix",
         provider=provider_mock.instance_id,
         name="Mood Mix",
-        items=[playlist],
+        items=UniqueList([playlist]),
     )
     provider_mock._pick_random_tag_for_category = AsyncMock(return_value="focus")
     provider_mock._get_mood_mix_recommendations = AsyncMock(return_value=folder)

--- a/tests/test_recommendations.py
+++ b/tests/test_recommendations.py
@@ -8,7 +8,7 @@ from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from music_assistant_models.enums import MediaType
+from music_assistant_models.enums import MediaType, ProviderFeature
 from music_assistant_models.errors import InvalidDataError
 from music_assistant_models.media_items import (
     Album,
@@ -33,6 +33,18 @@ _RECOMMENDATION_STRINGS = json.loads((provider_dir() / "strings.json").read_text
     "media"
 ]["recommendations"]
 
+ROW_IDS = [
+    MY_WAVE_PLAYLIST_ID,
+    "feed",
+    "chart",
+    "new_releases",
+    "new_playlists",
+    "top_picks",
+    "mood_mix",
+    "activity_mix",
+    "seasonal_mix",
+]
+
 
 @pytest.fixture
 def provider_mock() -> Mock:
@@ -40,6 +52,7 @@ def provider_mock() -> Mock:
     provider = Mock(spec=YandexMusicProvider)
     provider.domain = "yandex_music"
     provider.instance_id = "yandex_music_instance"
+    provider.supported_features = {ProviderFeature.RECOMMENDATIONS}
     provider.logger = Mock()
 
     # Mock client
@@ -796,96 +809,71 @@ async def test_get_seasonal_mix_recommendations_invalid_data_error(provider_mock
 
 
 @pytest.mark.asyncio
-async def test_recommendations_aggregates_all_folders(provider_mock: Mock) -> None:
-    """Test recommendations() aggregates all recommendation folders."""
-    # Mock all individual recommendation methods to return folders
-    mock_folder = Mock(spec=RecommendationFolder)
-    mock_folder.item_id = "test_folder"
-    mock_folder.name = "Test Folder"
+async def test_get_recommendations_returns_static_rows_without_backend_calls(
+    provider_mock: Mock,
+) -> None:
+    """Recommendation discovery returns ordered empty row descriptors."""
+    rows = await YandexMusicProvider.get_recommendations(provider_mock)
 
-    async def return_folder(*_args: Any, **_kwargs: Any) -> RecommendationFolder:
-        return mock_folder
-
-    async def return_tag(_category: str) -> str:
-        return "test_tag"
-
-    # Set the methods directly on the provider mock instance
-    provider_mock._get_my_wave_recommendations = return_folder
-    provider_mock._get_feed_recommendations = return_folder
-    provider_mock._get_chart_recommendations = return_folder
-    provider_mock._get_new_releases_recommendations = return_folder
-    provider_mock._get_new_playlists_recommendations = return_folder
-    provider_mock._get_top_picks_recommendations = return_folder
-    provider_mock._get_mood_mix_recommendations = return_folder
-    provider_mock._get_activity_mix_recommendations = return_folder
-    provider_mock._get_seasonal_mix_recommendations = return_folder
-    provider_mock._pick_random_tag_for_category = return_tag
-
-    result = await YandexMusicProvider.recommendations(provider_mock)
-
-    assert len(result) == 9  # All 9 methods returned folders
+    assert [row.item_id for row in rows] == ROW_IDS
+    assert all(not row.items for row in rows)
+    assert provider_mock.client.mock_calls == []
 
 
 @pytest.mark.asyncio
-async def test_recommendations_filters_none_folders(provider_mock: Mock) -> None:
-    """Test recommendations() filters out None results from individual methods."""
-    mock_folder = Mock(spec=RecommendationFolder)
-    mock_folder.item_id = "test_folder"
-    mock_folder.name = "Test Folder"
+async def test_get_recommendation_items_chart_triggers_only_chart_fetch(
+    provider_mock: Mock,
+) -> None:
+    """Loading Chart calls only the Chart row helper."""
+    track = Mock(spec=Track)
+    folder = RecommendationFolder(
+        item_id="chart",
+        provider=provider_mock.instance_id,
+        name="Chart",
+        items=[track],
+    )
+    provider_mock._get_chart_recommendations = AsyncMock(return_value=folder)
 
-    # Create async functions that return the desired values
-    async def return_folder(*_args: Any, **_kwargs: Any) -> RecommendationFolder:
-        return mock_folder
+    items = await YandexMusicProvider.get_recommendation_items(provider_mock, "chart")
 
-    async def return_none(*_args: Any, **_kwargs: Any) -> None:
-        return None
-
-    async def return_tag(_category: str) -> str:
-        return "test_tag"
-
-    # Set the methods directly on the provider mock instance
-    provider_mock._get_my_wave_recommendations = return_folder
-    provider_mock._get_feed_recommendations = return_none
-    provider_mock._get_chart_recommendations = return_folder
-    provider_mock._get_new_releases_recommendations = return_none
-    provider_mock._get_new_playlists_recommendations = return_folder
-    provider_mock._get_top_picks_recommendations = return_none
-    provider_mock._get_mood_mix_recommendations = return_folder
-    provider_mock._get_activity_mix_recommendations = return_none
-    provider_mock._get_seasonal_mix_recommendations = return_folder
-    provider_mock._pick_random_tag_for_category = return_tag
-
-    result = await YandexMusicProvider.recommendations(provider_mock)
-
-    # Should only return 5 folders (4 None were filtered out)
-    assert len(result) == 5
+    provider_mock._get_chart_recommendations.assert_awaited_once()
+    assert list(items) == [track]
+    assert provider_mock.client.mock_calls == []
 
 
 @pytest.mark.asyncio
-async def test_recommendations_returns_empty_list_when_all_none(provider_mock: Mock) -> None:
-    """Test recommendations() returns empty list when all methods return None."""
+async def test_get_recommendation_items_picks_tag_outside_cached_helper(
+    provider_mock: Mock,
+) -> None:
+    """Mood row chooses its rotating tag before calling the cached helper."""
+    playlist = Mock(spec=Playlist)
+    folder = RecommendationFolder(
+        item_id="mood_mix",
+        provider=provider_mock.instance_id,
+        name="Mood Mix",
+        items=[playlist],
+    )
+    provider_mock._pick_random_tag_for_category = AsyncMock(return_value="focus")
+    provider_mock._get_mood_mix_recommendations = AsyncMock(return_value=folder)
 
-    async def return_none(*_args: Any, **_kwargs: Any) -> None:
-        return None
+    items = await YandexMusicProvider.get_recommendation_items(provider_mock, "mood_mix")
 
-    async def return_no_tag(_category: str) -> None:
-        return None
+    provider_mock._pick_random_tag_for_category.assert_awaited_once_with("mood")
+    provider_mock._get_mood_mix_recommendations.assert_awaited_once_with("focus")
+    assert list(items) == [playlist]
 
-    # Set the methods directly on the provider mock instance
-    provider_mock._get_my_wave_recommendations = return_none
-    provider_mock._get_feed_recommendations = return_none
-    provider_mock._get_chart_recommendations = return_none
-    provider_mock._get_new_releases_recommendations = return_none
-    provider_mock._get_new_playlists_recommendations = return_none
-    provider_mock._get_top_picks_recommendations = return_none
-    provider_mock._get_mood_mix_recommendations = return_none
-    provider_mock._get_activity_mix_recommendations = return_none
-    provider_mock._get_seasonal_mix_recommendations = return_none
-    provider_mock._pick_random_tag_for_category = return_no_tag
 
-    result = await YandexMusicProvider.recommendations(provider_mock)
+@pytest.mark.asyncio
+async def test_get_recommendation_items_empty_or_unknown_returns_empty(
+    provider_mock: Mock,
+) -> None:
+    """Missing tags, empty helpers, and unknown row IDs yield an empty list."""
+    provider_mock._pick_random_tag_for_category = AsyncMock(return_value=None)
+    provider_mock._get_feed_recommendations = AsyncMock(return_value=None)
 
-    assert result == []
+    assert not await YandexMusicProvider.get_recommendation_items(provider_mock, "mood_mix")
+    assert not await YandexMusicProvider.get_recommendation_items(provider_mock, "feed")
+    assert not await YandexMusicProvider.get_recommendation_items(provider_mock, "unknown")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Reverse-sync of upstream PR https://github.com/music-assistant/server/pull/4487 into the standalone `yandex_music` provider.

## Standalone adaptation

Implements the current lazy recommendation API: `get_recommendations()` returns nine ordered empty descriptors without Yandex calls, while `get_recommendation_items(item_id)` loads only the selected row and returns the current `UniqueList` type.

Upstream author: @chrisuthe.

## Stack and review order

Includes #225 and #230. Review/merge order: #225, #230, then this PR. #228 follows this PR. All PRs intentionally remain based on `dev`.

## Verification

- [x] Spec completed (`specs/done/reverse-sync-pr4487.md`)
- [x] CHANGELOG entry finalized
- [x] RED API/routing behavior reproduced before implementation
- [x] Recommendation tests: 42 passed
- [x] Full Linux runtime suite: 360 passed, 7 snapshots passed
- [x] Ruff, Python AST, JSON, conflict scan, and method-order checks pass
- [x] GitHub reusable CI passes

Maintainer-owned version files were not changed.
