### PR TITLE
reverse-sync: Stabilize Mood/Activity recommendation subtitles (#4946)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Parser compatibility baselines now cover the `artist_entity_type` and `life_span` metadata fields introduced by current Music Assistant models.
 - Authentication token maintenance now uses `ya-passport-auth` 1.8.0, including its shared RFC 8628 polling improvements while retaining the existing refresh APIs.
+- Mood and Activity recommendation rows can show the localized tag selected for the current hourly rotation without making discovery-time backend requests.
 
 ### Removed
 

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 import random
 import uuid
@@ -1000,7 +1001,9 @@ class YandexMusicProvider(MusicProvider):
     async def get_recommendations(self) -> list[RecommendationFolder]:
         """Return static recommendation row descriptors without backend calls."""
         seasonal_tag = TAG_SEASONAL_MAP.get(utc().month, "autumn")
-        seasonal_name = seasonal_tag.title()
+        seasonal_name, _ = self._media_label(
+            "folder", _media_label_key(seasonal_tag), seasonal_tag.title()
+        )
         return [
             RecommendationFolder(
                 item_id=MY_WAVE_PLAYLIST_ID,
@@ -1049,6 +1052,7 @@ class YandexMusicProvider(MusicProvider):
                 provider=self.instance_id,
                 name="Mood Mix",
                 translation_key="mood_mix",
+                subtitle=await self._rotating_row_tag_subtitle("mood"),
                 icon="mdi-emoticon-outline",
             ),
             RecommendationFolder(
@@ -1056,6 +1060,7 @@ class YandexMusicProvider(MusicProvider):
                 provider=self.instance_id,
                 name="Activity Mix",
                 translation_key="activity_mix",
+                subtitle=await self._rotating_row_tag_subtitle("activity"),
                 icon="mdi-run",
             ),
             RecommendationFolder(
@@ -1086,11 +1091,15 @@ class YandexMusicProvider(MusicProvider):
         elif item_id == "top_picks":
             folder = await self._get_top_picks_recommendations()
         elif item_id == "mood_mix":
-            if tag := await self._pick_random_tag_for_category("mood"):
-                folder = await self._get_mood_mix_recommendations(tag)
+            if tags := await self._get_valid_tags_for_category("mood"):
+                folder = await self._get_mood_mix_recommendations(
+                    self._rotating_row_tag("mood", tags)
+                )
         elif item_id == "activity_mix":
-            if tag := await self._pick_random_tag_for_category("activity"):
-                folder = await self._get_activity_mix_recommendations(tag)
+            if tags := await self._get_valid_tags_for_category("activity"):
+                folder = await self._get_activity_mix_recommendations(
+                    self._rotating_row_tag("activity", tags)
+                )
         elif item_id == "seasonal_mix":
             folder = await self._get_seasonal_mix_recommendations()
         return folder.items if folder else UniqueList()
@@ -3428,18 +3437,6 @@ class YandexMusicProvider(MusicProvider):
             icon="mdi-star",
         )
 
-    async def _pick_random_tag_for_category(self, category: str) -> str | None:
-        """
-        Pick a random valid tag for a category (not cached — enables rotation).
-
-        :param category: Category name ('mood', 'activity', etc.).
-        :return: Random tag slug, or None if no valid tags.
-        """
-        valid_tags = await self._get_valid_tags_for_category(category)
-        if not valid_tags:
-            return None
-        return random.choice(valid_tags)
-
     @use_cache(1800, allow_expired_cache=True)
     async def _get_mood_mix_recommendations(self, mood_tag: str) -> RecommendationFolder | None:
         """
@@ -3848,3 +3845,36 @@ class YandexMusicProvider(MusicProvider):
             total_played_seconds=offset,
             end_position_seconds=offset,
         )
+
+    async def _rotating_row_tag_subtitle(self, category: str) -> str | None:
+        """
+        Return the current rotating tag label from cache without backend I/O.
+
+        :param category: Tag category, such as ``mood`` or ``activity``.
+        :return: Localized tag label, or ``None`` while the cache is cold.
+        """
+        tags, _, found = await self.mass.cache.get_with_freshness(
+            f"_get_valid_tags_for_category.{category}",
+            provider=self.instance_id,
+            include_expired=True,
+        )
+        if not found or not isinstance(tags, list):
+            return None
+        valid_tags = [tag for tag in tags if isinstance(tag, str)]
+        if not valid_tags:
+            return None
+        tag = self._rotating_row_tag(category, valid_tags)
+        return self._media_label("folder", _media_label_key(tag), tag.title())[0]
+
+    def _rotating_row_tag(self, category: str, valid_tags: list[str]) -> str:
+        """
+        Deterministically select a tag for this provider and UTC hour.
+
+        :param category: Tag category the values belong to.
+        :param valid_tags: Non-empty ordered tag list.
+        :return: The selected tag slug.
+        """
+        hour_bucket = int(utc().timestamp()) // 3600
+        seed = f"{self.instance_id}.{category}.{hour_bucket}".encode()
+        index = int.from_bytes(hashlib.sha256(seed).digest()[:8], "big") % len(valid_tags)
+        return valid_tags[index]

--- a/specs/done/reverse-sync-pr4946.md
+++ b/specs/done/reverse-sync-pr4946.md
@@ -1,0 +1,23 @@
+# Reverse-sync: upstream PR #4946
+
+Ported from music-assistant/server#4946 into `yandex_music`.
+
+## Summary
+
+Add cache-only subtitles to the Mood and Activity recommendation rows and use
+the same deterministic hourly tag selection when their items are loaded. This
+keeps row metadata aligned with served content without adding discovery-time
+Yandex requests or mutable provider state.
+
+## Acceptance criteria
+
+- Warm tag caches produce localized Mood and Activity subtitles.
+- Cold caches produce no subtitle and trigger no backend request.
+- Tag selection is stable for a provider, category, and UTC hour.
+- Mood and Activity item loading uses the same deterministic selector.
+- Empty tag lists continue to return empty rows.
+- No recommendation cache owned outside the provider instance is cleared.
+
+## Test plan
+
+Run `tests/test_recommendations.py`, then the full repository quality gate.

--- a/tests/test_recommendations.py
+++ b/tests/test_recommendations.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import pathlib
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -843,7 +845,7 @@ async def test_get_recommendation_items_chart_triggers_only_chart_fetch(
 
 
 @pytest.mark.asyncio
-async def test_get_recommendation_items_picks_tag_outside_cached_helper(
+async def test_get_recommendation_items_uses_deterministic_tag_outside_cached_helper(
     provider_mock: Mock,
 ) -> None:
     """Mood row chooses its rotating tag before calling the cached helper."""
@@ -854,12 +856,14 @@ async def test_get_recommendation_items_picks_tag_outside_cached_helper(
         name="Mood Mix",
         items=UniqueList([playlist]),
     )
-    provider_mock._pick_random_tag_for_category = AsyncMock(return_value="focus")
+    provider_mock._get_valid_tags_for_category = AsyncMock(return_value=["focus", "chill"])
+    provider_mock._rotating_row_tag = Mock(return_value="focus")
     provider_mock._get_mood_mix_recommendations = AsyncMock(return_value=folder)
 
     items = await YandexMusicProvider.get_recommendation_items(provider_mock, "mood_mix")
 
-    provider_mock._pick_random_tag_for_category.assert_awaited_once_with("mood")
+    provider_mock._get_valid_tags_for_category.assert_awaited_once_with("mood")
+    provider_mock._rotating_row_tag.assert_called_once_with("mood", ["focus", "chill"])
     provider_mock._get_mood_mix_recommendations.assert_awaited_once_with("focus")
     assert list(items) == [playlist]
 
@@ -869,12 +873,65 @@ async def test_get_recommendation_items_empty_or_unknown_returns_empty(
     provider_mock: Mock,
 ) -> None:
     """Missing tags, empty helpers, and unknown row IDs yield an empty list."""
-    provider_mock._pick_random_tag_for_category = AsyncMock(return_value=None)
+    provider_mock._get_valid_tags_for_category = AsyncMock(return_value=[])
     provider_mock._get_feed_recommendations = AsyncMock(return_value=None)
 
     assert not await YandexMusicProvider.get_recommendation_items(provider_mock, "mood_mix")
     assert not await YandexMusicProvider.get_recommendation_items(provider_mock, "feed")
     assert not await YandexMusicProvider.get_recommendation_items(provider_mock, "unknown")
+
+
+@pytest.mark.asyncio
+async def test_rotating_row_tag_subtitle_from_warm_cache(provider_mock: Mock) -> None:
+    """A warm tag cache produces a localized rotating-row subtitle."""
+    provider_mock.mass.cache.get_with_freshness = AsyncMock(
+        return_value=(["chill", "focus"], True, True)
+    )
+    provider_mock._rotating_row_tag = YandexMusicProvider._rotating_row_tag.__get__(
+        provider_mock, YandexMusicProvider
+    )
+
+    label = await YandexMusicProvider._rotating_row_tag_subtitle(provider_mock, "mood")
+
+    assert label in {"Chill", "Focus"}
+    provider_mock.client.get_landing_tags.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rotating_row_tag_subtitle_cold_cache_returns_none(provider_mock: Mock) -> None:
+    """Descriptor discovery avoids I/O when the tag cache is cold."""
+    provider_mock.mass.cache.get_with_freshness = AsyncMock(return_value=(None, False, False))
+
+    label = await YandexMusicProvider._rotating_row_tag_subtitle(provider_mock, "activity")
+
+    assert label is None
+    provider_mock.client.get_landing_tags.assert_not_awaited()
+
+
+def test_rotating_row_tag_is_deterministic_and_category_scoped(provider_mock: Mock) -> None:
+    """Hourly tag selection is stable and incorporates the category."""
+    fixed_now = datetime(2026, 7, 30, 12, tzinfo=UTC)
+    tags = ["chill", "focus", "happy", "calm"]
+
+    with (
+        patch(
+            "music_assistant.providers.yandex_music.provider.utc",
+            return_value=fixed_now,
+        ),
+        patch(
+            "music_assistant.providers.yandex_music.provider.hashlib.sha256",
+            wraps=hashlib.sha256,
+        ) as sha256,
+    ):
+        mood_first = YandexMusicProvider._rotating_row_tag(provider_mock, "mood", tags)
+        mood_second = YandexMusicProvider._rotating_row_tag(provider_mock, "mood", tags)
+        activity = YandexMusicProvider._rotating_row_tag(provider_mock, "activity", tags)
+
+    assert mood_first == mood_second
+    assert mood_first in tags
+    assert activity in tags
+    assert sha256.call_args_list[0].args == sha256.call_args_list[1].args
+    assert sha256.call_args_list[0].args != sha256.call_args_list[2].args
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Reverse-sync of upstream PR https://github.com/music-assistant/server/pull/4946 into the standalone `yandex_music` provider.

## Standalone adaptation

Adds cache-only Mood/Activity subtitles and selects their tags deterministically from `(provider instance, category, UTC hour)`. Descriptor discovery never performs a cold Yandex request, and item loading independently derives the same tag. No mutable recommendation state is introduced, so unload needs no additional cleanup.

Upstream author: @marcelveldt.

## Stack and review order

Includes #225, #230, and #226. Review/merge this PR only after #226. All PRs intentionally remain based on `dev`.

## Verification

- [x] Spec completed (`specs/done/reverse-sync-pr4946.md`)
- [x] CHANGELOG entry finalized
- [x] RED cache/subtitle behavior reproduced before implementation
- [x] Recommendation tests: 45 passed
- [x] Full Linux runtime suite: 363 passed, 7 snapshots passed
- [x] Ruff, Python AST, conflict scan, and method-order checks pass
- [x] GitHub reusable CI passes

Maintainer-owned version files were not changed.
