### PR TITLE
reverse-sync: Retire the AUTH_SESSION auth-popup mechanism (#5030)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -63,13 +63,13 @@ The provider is a single Python package in `provider/` that MA loads via `manife
 | `api_client.py` | `YandexMusicClient` — thin async wrapper around `yandex-music`'s `ClientAsync`; handles auth, retries, rate limiting (5 req/s), and all Yandex API calls |
 | `parsers.py` | Pure functions (`parse_track`, `parse_album`, `parse_artist`, `parse_playlist`) that convert Yandex API objects into MA model objects |
 | `streaming.py` | `YandexMusicStreamingManager` — resolves stream URLs, selects quality, handles AES decryption of FLAC streams |
-| `auth.py` | Async functions for both login flows (`perform_qr_auth`, `perform_device_auth`) and token maintenance (`refresh_music_token`, `refresh_credentials_via_passport`, `validate_x_token`) — all delegating to the `ya-passport-auth` library |
+| `auth.py` | Token-maintenance wrappers (`refresh_music_token`, `refresh_credentials_via_passport`, `validate_x_token`) delegating to the `ya-passport-auth` library |
 | `constants.py` | All string constants, IDs, quality labels, locale display-name dicts, tag/category mappings |
-| `__init__.py` | Provider config schema (QR auth action, token fields, quality picker, limits) and `setup()` / `get_config_entries()` |
+| `__init__.py` | Provider config schema (manual token fields, quality picker, limits) and `setup()` / `get_config_entries()` |
 
 **Data flow:** `provider.py` → `api_client.py` (fetch raw Yandex objects) → `parsers.py` (convert to MA models) → returned to MA core. Streaming is a separate path: `provider.get_stream_details()` → `streaming.get_stream_details()` → `provider.get_audio_stream()` → `streaming.get_audio_stream()`.
 
-**Auth flow:** `__init__.py` (QR or Device Flow action clicked) → `auth.perform_qr_auth()` / `auth.perform_device_auth()` → `ya-passport-auth` library (session + polling) → returns tokens → stored in MA config. Token refresh: `provider.py` → `auth.refresh_music_token()` / `auth.refresh_credentials_via_passport()`.
+**Auth flow:** `__init__.py` accepts a manually supplied music token. Existing stored `x_token` and `refresh_token` credentials are maintained by `provider.py` through `auth.refresh_music_token()` / `auth.refresh_credentials_via_passport()`.
 
 **Import path in tests:** The provider is imported as `music_assistant.providers.yandex_music.*` (not via relative imports), matching how MA loads it at runtime.
 
@@ -80,7 +80,7 @@ The provider is a single Python package in `provider/` that MA loads via `manife
 - `api_client.py` constructor takes `SecretStr`; calls `.get_secret()` only once inside `connect()`
 - `provider.py` wraps config strings in `SecretStr()` before passing to `api_client` — this is a **runtime** import, not `TYPE_CHECKING`
 - `api_client.py` imports `SecretStr` under `TYPE_CHECKING` (only used in type annotations; `.get_secret()` is called on the instance)
-- Auth functions in `auth.py` accept `SecretStr`, return plain strings for MA config storage
+- Auth functions in `auth.py` accept `SecretStr` and return `SecretStr` or `Credentials`; `provider.py` extracts plaintext only when persisting refreshed values
 
 ### Item ID formats
 - **Regular tracks:** plain `track_id` string
@@ -96,7 +96,7 @@ Parser functions in `parsers.py` follow the signature `parse_*(provider, yandex_
 - Parser output is snapshot-tested via `syrupy`; snapshots live in `tests/__snapshots__/test_parsers.ambr`
 - To update snapshots after an intentional parser change: `pytest tests/test_parsers.py --snapshot-update`
 - `tests/conftest.py` provides hand-written stubs (not `Mock`): `ProviderStub`, `ConfigStub`, `StreamingProviderStub`, `StreamingProviderStubWithTracking` (with `TrackingLogger`)
-- Auth tests (`test_auth.py`) use `mock.patch` on `PassportClient.create` (async context manager) and `AuthenticationHelper`
+- Auth tests (`test_auth.py`) patch `PassportClient.create` as an async context manager and cover refresh/error-mapping behavior
 
 ### Branch naming and commits
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Parser compatibility baselines now cover the `artist_entity_type` and `life_span` metadata fields introduced by current Music Assistant models.
 
+### Removed
+
+- Device-code and QR popup sign-in actions that depended on authentication helpers removed by current Music Assistant; manual music-token entry and silent refresh for existing stored credentials remain available.
+
 ## [3.8.3] - 2026-07-16
 
 - fix(tests): `_MockResponse.__aenter__` returns `Self` (PYI034), per the upstream dev ruff rules.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Parser compatibility baselines now cover the `artist_entity_type` and `life_span` metadata fields introduced by current Music Assistant models.
+- Authentication token maintenance now uses `ya-passport-auth` 1.8.0, including its shared RFC 8628 polling improvements while retaining the existing refresh APIs.
 
 ### Removed
 

--- a/provider/__init__.py
+++ b/provider/__init__.py
@@ -11,10 +11,7 @@ from music_assistant_models.errors import InvalidDataError
 
 from music_assistant.constants import CONF_ENTRY_UNOFFICIAL_PROVIDER
 
-from .auth import perform_device_auth, perform_qr_auth
 from .constants import (
-    CONF_ACTION_AUTH_DEVICE,
-    CONF_ACTION_AUTH_QR,
     CONF_ACTION_CLEAR_AUTH,
     CONF_ACTION_DELETE_WAVE_PRESET,
     CONF_ACTION_SAVE_WAVE_PRESET,
@@ -23,9 +20,7 @@ from .constants import (
     CONF_MY_WAVE_MAX_TRACKS,
     CONF_QUALITY,
     CONF_REFRESH_TOKEN,
-    CONF_REMEMBER_SESSION,
     CONF_RESTRICTIVE_RATE_LIMITS,
-    CONF_SESSION_ID,
     CONF_TOKEN,
     CONF_WAVE_PRESET_DRAFT_DIVERSITY,
     CONF_WAVE_PRESET_DRAFT_LANGUAGE,
@@ -250,7 +245,7 @@ async def setup(
 
 
 async def get_config_entries(
-    mass: MusicAssistant,
+    mass: MusicAssistant,  # noqa: ARG001
     instance_id: str | None = None,  # noqa: ARG001
     action: str | None = None,
     values: dict[str, ConfigValueType] | None = None,
@@ -258,36 +253,6 @@ async def get_config_entries(
     """Return Config entries to setup this provider."""
     if values is None:
         values = {}
-
-    # Handle QR auth action
-    if action == CONF_ACTION_AUTH_QR:
-        session_id = values.get(CONF_SESSION_ID)
-        if not session_id:
-            raise InvalidDataError("Missing session_id for QR authentication")
-        x_token, music_token = await perform_qr_auth(mass, str(session_id))
-        values[CONF_TOKEN] = music_token
-        if values.get(CONF_REMEMBER_SESSION, True):
-            values[CONF_X_TOKEN] = x_token
-        else:
-            values[CONF_X_TOKEN] = None
-        # QR flow never yields a refresh_token — clear any stale one from a
-        # prior device-flow login so we don't leave dead credentials behind
-        values[CONF_REFRESH_TOKEN] = None
-
-    # Handle Device Flow auth action (yields x_token + refresh_token,
-    # so we get silent auto-refresh on music-token AND x_token expiry)
-    if action == CONF_ACTION_AUTH_DEVICE:
-        session_id = values.get(CONF_SESSION_ID)
-        if not session_id:
-            raise InvalidDataError("Missing session_id for device authentication")
-        x_token, music_token, refresh_token = await perform_device_auth(mass, str(session_id))
-        values[CONF_TOKEN] = music_token
-        if values.get(CONF_REMEMBER_SESSION, True):
-            values[CONF_X_TOKEN] = x_token
-            values[CONF_REFRESH_TOKEN] = refresh_token
-        else:
-            values[CONF_X_TOKEN] = None
-            values[CONF_REFRESH_TOKEN] = None
 
     # Handle clear auth action
     if action == CONF_ACTION_CLEAR_AUTH:
@@ -308,18 +273,8 @@ async def get_config_entries(
     # Dynamic status label: English fallback in code, localized via the
     # per-state translation key authored in strings.json.
     if not is_authenticated:
-        label_text = (
-            "Open a verification URL on any device and enter the short code, "
-            "or scan a QR code with the Yandex app on your phone.\n\n"
-            "Alternatively, you can enter a music token manually in the advanced settings."
-        )
+        label_text = "Enter a Yandex Music token in the advanced settings."
         label_translation_key = "auth_status_unauthenticated"
-    elif action in (CONF_ACTION_AUTH_QR, CONF_ACTION_AUTH_DEVICE):
-        label_text = (
-            "⚠ Authenticated to Yandex Music — click Save now to finish, "
-            "otherwise the login will be lost."
-        )
-        label_translation_key = "auth_status_save_required"
     else:
         label_text = "Authenticated to Yandex Music."
         label_translation_key = "auth_status_authenticated"
@@ -333,27 +288,6 @@ async def get_config_entries(
             label=label_text,
             translation_key=label_translation_key,
         ),
-        # Device Flow authentication (primary)
-        ConfigEntry(
-            key=CONF_ACTION_AUTH_DEVICE,
-            type=ConfigEntryType.ACTION,
-            action=CONF_ACTION_AUTH_DEVICE,
-            hidden=is_authenticated,
-        ),
-        # QR authentication (alternative)
-        ConfigEntry(
-            key=CONF_ACTION_AUTH_QR,
-            type=ConfigEntryType.ACTION,
-            action=CONF_ACTION_AUTH_QR,
-            hidden=is_authenticated,
-        ),
-        # Remember session toggle
-        ConfigEntry(
-            key=CONF_REMEMBER_SESSION,
-            type=ConfigEntryType.BOOLEAN,
-            default_value=True,
-            hidden=is_authenticated,
-        ),
         # Clear auth
         ConfigEntry(
             key=CONF_ACTION_CLEAR_AUTH,
@@ -361,7 +295,7 @@ async def get_config_entries(
             action=CONF_ACTION_CLEAR_AUTH,
             hidden=not is_authenticated,
         ),
-        # Token storage (populated by QR action or manual entry)
+        # Manual token setup
         ConfigEntry(
             key=CONF_TOKEN,
             type=ConfigEntryType.SECURE_STRING,

--- a/provider/auth.py
+++ b/provider/auth.py
@@ -1,41 +1,11 @@
-"""
-Yandex Music authentication flows.
-
-Thin provider-side wrappers over the shared Music Assistant auth layer in
-``ya_passport_auth.ma`` (device-code page, QR flow, token maintenance with
-unified error mapping). This module only pins the provider-specific page
-branding and the tuple-shaped return values the config flow expects.
-
-* **QR flow** — :func:`perform_qr_auth` opens a QR popup via the MA frontend
-  and polls Passport until the user scans/confirms. Yields
-  ``(x_token, music_token)``.
-* **Device Flow** — :func:`perform_device_auth` serves a short user code on
-  an MA-hosted intermediate page and polls Passport until confirmation.
-  Yields the full ``(x_token, music_token, refresh_token)`` triple.
-
-Token maintenance helpers (:func:`refresh_music_token`,
-:func:`refresh_credentials_via_passport`, :func:`validate_x_token`) live
-alongside the login flows.
-"""
+"""Yandex Music token-maintenance wrappers."""
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING
 
-from music_assistant_models.errors import LoginFailed
-
-# PassportClient is re-imported here (not used directly) so the test-suite's
-# established patch target `<this module>.PassportClient.create` keeps
-# working — patching the classmethod mutates the class object shared with
-# the ya_passport_auth.ma flows.
+# Re-exported as the stable patch target for token-maintenance tests.
 from ya_passport_auth import PassportClient  # noqa: F401
-from ya_passport_auth.ma import (
-    DevicePageConfig,
-    require_music_token,
-    run_device_flow,
-    run_qr_flow,
-)
 from ya_passport_auth.ma import (
     refresh_credentials as _refresh_credentials,
 )
@@ -48,55 +18,6 @@ from ya_passport_auth.ma import (
 
 if TYPE_CHECKING:
     from ya_passport_auth import Credentials, SecretStr
-
-    from music_assistant import MusicAssistant
-
-_LOGGER = logging.getLogger(__name__)
-
-# Provider-specific branding of the shared device-code page; everything else
-# (layout, localization, countdown, failure reasons) comes from the library
-# and is translated via this provider's strings.json (page.device_code.*).
-PAGE_CONFIG = DevicePageConfig(
-    domain="yandex_music",
-    title={"en": "Login to Yandex Music", "ru": "Вход в Яндекс Музыку"},
-)
-
-
-async def perform_device_auth(mass: MusicAssistant, session_id: str) -> tuple[str, str, str]:
-    """
-    Perform Yandex OAuth Device Flow and return credential tokens.
-
-    Asks Yandex for a device code, presents it to the user via an
-    MA-hosted intermediate page, then polls until the user confirms or the
-    code expires. Returns (or raises) as soon as the outcome is known.
-
-    Returns (x_token, music_token, refresh_token) as plain strings for MA
-    config storage.
-    """
-    result = await run_device_flow(mass, session_id, PAGE_CONFIG)
-    creds = result.credentials
-    music_token = require_music_token(creds, flow="Device")
-    refresh_token = creds.refresh_token
-    if refresh_token is None:
-        raise LoginFailed("Device auth succeeded but no refresh token was returned")
-    _LOGGER.debug("Device flow complete, obtained full credential triple")
-    return (creds.x_token.get_secret(), music_token, refresh_token.get_secret())
-
-
-async def perform_qr_auth(mass: MusicAssistant, session_id: str) -> tuple[str, str]:
-    """
-    Perform full QR authentication flow.
-
-    Opens a QR code popup via MA frontend, polls for scan confirmation,
-    then returns tokens as plain strings for MA config storage.
-
-    Returns (x_token, music_token).
-    """
-    result = await run_qr_flow(mass, session_id)
-    creds = result.credentials
-    music_token = require_music_token(creds, flow="QR")
-    _LOGGER.debug("QR auth complete, obtained both tokens")
-    return creds.x_token.get_secret(), music_token
 
 
 async def refresh_music_token(x_token: SecretStr) -> SecretStr:

--- a/provider/constants.py
+++ b/provider/constants.py
@@ -10,17 +10,11 @@ CONF_QUALITY: Final[str] = "quality"
 CONF_BASE_URL: Final[str] = "base_url"
 
 # Actions
-CONF_ACTION_AUTH_QR: Final[str] = "auth_qr"
-CONF_ACTION_AUTH_DEVICE: Final[str] = "auth_device"
 CONF_ACTION_CLEAR_AUTH: Final[str] = "clear_auth"
 
-# QR authentication config keys
+# Stored authentication credentials
 CONF_X_TOKEN: Final[str] = "x_token"
 CONF_REFRESH_TOKEN: Final[str] = "refresh_token"
-CONF_REMEMBER_SESSION: Final[str] = "remember_session"
-
-# Session-id key handed to the QR / Device-flow handlers from the MA config flow.
-CONF_SESSION_ID: Final[str] = "session_id"
 
 # Advanced toggle: enable a token-wide concurrency cap to keep MA below
 # Yandex's per-token edge concurrency limit on datacenter / VPN IPs

--- a/provider/manifest.json
+++ b/provider/manifest.json
@@ -7,6 +7,6 @@
   "codeowners": ["@TrudenBoy"],
   "credits": ["[yandex-music-api](https://github.com/MarshalX/yandex-music-api)"],
   "documentation": "https://music-assistant.io/music-providers/yandex-music/",
-  "requirements": ["yandex-music==3.0.0", "ya-passport-auth[ma]==1.7.0"],
+  "requirements": ["yandex-music==3.0.0", "ya-passport-auth[ma]==1.8.0"],
   "multi_instance": true
 }

--- a/provider/strings.json
+++ b/provider/strings.json
@@ -41,20 +41,6 @@
     "wave_presets_data": {
       "label": "Saved presets (internal)"
     },
-    "auth_device": {
-      "label": "[%key:common::config_entries::auth_device::label%]",
-      "description": "[%key:common::config_entries::auth_device::description%]",
-      "action_label": "[%key:common::config_entries::auth_device::action_label%]"
-    },
-    "auth_qr": {
-      "label": "[%key:common::config_entries::auth_qr::label%]",
-      "description": "[%key:common::config_entries::auth_qr::description%]",
-      "action_label": "[%key:common::config_entries::auth_qr::action_label%]"
-    },
-    "remember_session": {
-      "label": "[%key:common::config_entries::remember_session::label%]",
-      "description": "[%key:common::config_entries::remember_session::description%]"
-    },
     "clear_auth": {
       "label": "[%key:common::config_entries::clear_auth::label%]",
       "description": "[%key:common::config_entries::clear_auth::description%]",
@@ -97,10 +83,7 @@
       "description": "Enable when Music Assistant runs on a VPS, NAS-behind-VPN, or any datacenter IP. Caps total in-flight requests to Yandex below the edge concurrency limit observed for those IPs (~6 simultaneous), trading some browse / recommendations responsiveness for fewer captcha trips. Residential users do not need this — Yandex tolerates much higher concurrency from regular ISPs."
     },
     "auth_status_unauthenticated": {
-      "label": "Open a verification URL on any device and enter the short code, or scan a QR code with the Yandex app on your phone.\n\nAlternatively, you can enter a music token manually in the advanced settings."
-    },
-    "auth_status_save_required": {
-      "label": "⚠ Authenticated to Yandex Music — click Save now to finish, otherwise the login will be lost."
+      "label": "Enter a Yandex Music token in the advanced settings."
     },
     "auth_status_authenticated": {
       "label": "Authenticated to Yandex Music."
@@ -347,26 +330,5 @@
   },
   "manifest": {
     "description": "Stream music, personalized recommendations, and lossless FLAC from Yandex Music — including My Wave radio and library sync."
-  },
-  "page": {
-    "device_code": {
-      "title": "Login to Yandex Music",
-      "step_copy": "[%key:common::page::device_code::step_copy%]",
-      "hint_copy": "[%key:common::page::device_code::hint_copy%]",
-      "copied": "[%key:common::page::device_code::copied%]",
-      "copy_manual": "[%key:common::page::device_code::copy_manual%]",
-      "step_open": "[%key:common::page::device_code::step_open%]",
-      "open_button": "[%key:common::page::device_code::open_button%]",
-      "expires_label": "[%key:common::page::device_code::expires_label%]",
-      "expired_title": "[%key:common::page::device_code::expired_title%]",
-      "expired_text": "[%key:common::page::device_code::expired_text%]",
-      "success_title": "[%key:common::page::device_code::success_title%]",
-      "success_text": "[%key:common::page::device_code::success_text%]",
-      "failed_title": "[%key:common::page::device_code::failed_title%]",
-      "failed_text": "[%key:common::page::device_code::failed_text%]",
-      "denied_text": "[%key:common::page::device_code::denied_text%]",
-      "ended_title": "[%key:common::page::device_code::ended_title%]",
-      "ended_text": "[%key:common::page::device_code::ended_text%]"
-    }
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Yandex Music provider for Music Assistant"
 requires-python = ">=3.14"
 dynamic = ["version"]
 dependencies = [
-  "ya-passport-auth[ma]==1.7.0",
+  "ya-passport-auth[ma]==1.8.0",
   "yandex-music==3.0.0",
 ]
 

--- a/specs/done/reverse-sync-pr5030.md
+++ b/specs/done/reverse-sync-pr5030.md
@@ -1,0 +1,24 @@
+# Reverse-sync: upstream PR #5030
+
+Ported from music-assistant/server#5030 into `yandex_music`.
+
+## Summary
+
+Remove the Device and QR popup authentication actions after Music Assistant
+retired its shared popup helper. New installations authenticate by entering a
+Yandex Music token in advanced settings. Existing stored x-token and refresh
+token values remain hidden and continue to support silent credential refresh.
+
+## Acceptance criteria
+
+- Config entries no longer expose Device, QR, remember-session, or session-id
+  controls.
+- Manual music-token entry and clear-auth remain available.
+- Stored x-token and refresh-token values are preserved by the config flow.
+- Token validation and refresh helpers retain their error mapping and redaction.
+- No provider or test code imports `music_assistant.helpers.auth`.
+
+## Test plan
+
+Run the auth, config-entry, and localization tests, then the full repository
+quality gate.

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,85 +1,20 @@
-"""Unit tests for auth.py (ya-passport-auth QR + Device Flow)."""
+"""Unit tests for Yandex Music token maintenance."""
 
 from __future__ import annotations
 
-import asyncio
-import contextlib
-import json
-from collections.abc import AsyncGenerator, Awaitable, Callable, Generator, Iterator
-from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
 from music_assistant_models.errors import LoginFailed, ResourceTemporarilyUnavailable
-from ya_passport_auth import Credentials, DeviceCodeSession, QrSession, SecretStr
-from ya_passport_auth.exceptions import (
-    DeviceCodeTimeoutError,
-    InvalidCredentialsError,
-    QRTimeoutError,
-    RateLimitedError,
-    YaPassportError,
-)
-from ya_passport_auth.exceptions import (
-    NetworkError as PassportNetworkError,
-)
+from ya_passport_auth import Credentials, SecretStr
+from ya_passport_auth.exceptions import InvalidCredentialsError, RateLimitedError
+from ya_passport_auth.exceptions import NetworkError as PassportNetworkError
 
 from music_assistant.providers.yandex_music.auth import (
-    perform_device_auth,
-    perform_qr_auth,
     refresh_credentials_via_passport,
     refresh_music_token,
     validate_x_token,
 )
-
-if TYPE_CHECKING:
-    from aiohttp import web
-
-
-@pytest.fixture(autouse=True)
-def skip_grace_sleep() -> Generator[mock.AsyncMock]:
-    """Bypass the post-auth grace ``asyncio.sleep`` so tests run instantly."""
-    with mock.patch(
-        "ya_passport_auth.ma.routes.asyncio.sleep",
-        new=mock.AsyncMock(),
-    ) as patched:
-        yield patched
-
-
-@pytest.fixture(autouse=True)
-async def drain_teardown_tasks(
-    skip_grace_sleep: mock.AsyncMock,  # noqa: ARG001 — orders teardown before the patch exits
-) -> AsyncGenerator[None]:
-    """
-    Settle deferred route-teardown tasks before the grace-sleep patch exits.
-
-    Cancels leftovers instead of awaiting them so a test that failed before
-    releasing a hung grace sleep cannot deadlock the whole run.
-    """
-    yield
-    pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
-    for task in pending:
-        task.cancel()
-    if pending:
-        await asyncio.gather(*pending, return_exceptions=True)
-
-
-# -- helpers -------------------------------------------------------------------
-
-
-def _make_device_session(
-    user_code: str = "ABCD-1234",
-    verification_url: str = "https://oauth.yandex.ru/device",
-    interval: int = 1,
-    expires_in: int = 600,
-) -> DeviceCodeSession:
-    """Build a DeviceCodeSession for testing."""
-    return DeviceCodeSession(
-        device_code=SecretStr("dev-code-xyz"),
-        user_code=user_code,
-        verification_url=verification_url,
-        expires_in=expires_in,
-        interval=interval,
-    )
 
 
 def _make_credentials(
@@ -87,706 +22,12 @@ def _make_credentials(
     music_token: str | None = "test_music_token",  # noqa: S107
     refresh_token: str | None = "test_refresh_token",  # noqa: S107
 ) -> Credentials:
-    """Build a Credentials dataclass for testing."""
+    """Build credentials for token-maintenance tests."""
     return Credentials(
         x_token=SecretStr(x_token),
         music_token=SecretStr(music_token) if music_token else None,
         refresh_token=SecretStr(refresh_token) if refresh_token else None,
     )
-
-
-def _make_qr_session() -> QrSession:
-    """Build a QrSession for testing."""
-    return QrSession(
-        track_id="track123",
-        csrf_token="csrf_abc",
-        qr_url="https://passport.yandex.ru/auth/magic/code/?track_id=track123",
-    )
-
-
-class _FakeWebserver:
-    """Dict-backed webserver stub mirroring MA's dynamic-route semantics."""
-
-    base_url = "http://ma.local:8095"
-
-    def __init__(self) -> None:
-        self.routes: dict[tuple[str, str], object] = {}
-        self.unregister_calls: list[str] = []
-        self.unregister_error: Exception | None = None
-
-    def register_dynamic_route(self, path: str, handler: object, method: str = "*") -> None:
-        key = (path, method)
-        if key in self.routes:
-            raise RuntimeError(f"Route {path} already registered.")
-        self.routes[key] = handler
-
-    def unregister_dynamic_route(self, path: str, method: str = "*") -> None:
-        self.unregister_calls.append(path)
-        if self.unregister_error is not None:
-            error, self.unregister_error = self.unregister_error, None
-            raise error
-        self.routes.pop((path, method), None)
-
-
-def _make_mass(webserver: _FakeWebserver | None = None) -> mock.MagicMock:
-    """Build a mass mock whose create_task actually schedules coroutines."""
-    mock_mass = mock.MagicMock()
-    if webserver is not None:
-        mock_mass.webserver = webserver
-    else:
-        mock_mass.webserver.base_url = "http://ma.local:8095"
-    mock_mass.create_task.side_effect = asyncio.create_task
-    return mock_mass
-
-
-@contextlib.contextmanager
-def _patched_flow(mock_client: mock.AsyncMock, mock_auth_helper: mock.AsyncMock) -> Iterator[None]:
-    """Patch PassportClient.create + AuthenticationHelper around a flow call."""
-    with (
-        mock.patch(
-            "music_assistant.providers.yandex_music.auth.PassportClient.create",
-        ) as mock_create,
-        mock.patch(
-            "music_assistant.helpers.auth.AuthenticationHelper",
-            return_value=mock_auth_helper,
-        ),
-    ):
-        mock_create.return_value.__aenter__ = mock.AsyncMock(return_value=mock_client)
-        mock_create.return_value.__aexit__ = mock.AsyncMock(return_value=False)
-        yield
-
-
-async def _drain_background_tasks() -> None:
-    """Await every task except the current one (route-teardown tasks)."""
-    pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
-    if pending:
-        await asyncio.gather(*pending, return_exceptions=True)
-
-
-async def _render_device_page(
-    mock_mass: mock.MagicMock,
-    session: DeviceCodeSession | None = None,
-) -> str:
-    """Run a successful device flow and return the intermediate page HTML."""
-    session = session or _make_device_session()
-    creds = _make_credentials()
-    mock_client = mock.AsyncMock()
-    mock_client.start_device_login.return_value = session
-    mock_client.poll_device_until_confirmed.return_value = creds
-    mock_auth_helper = mock.AsyncMock()
-
-    with _patched_flow(mock_client, mock_auth_helper):
-        await perform_device_auth(mock_mass, "session_page")
-
-    page_call = next(
-        c
-        for c in mock_mass.webserver.register_dynamic_route.call_args_list
-        if not c.args[0].endswith("/status")
-    )
-    handler = page_call.args[1]
-    response = await handler(mock.MagicMock())
-    await _drain_background_tasks()
-    body = response.text
-    assert isinstance(body, str)
-    return body
-
-
-# -- perform_device_auth -------------------------------------------------------
-
-
-async def test_perform_device_auth_returns_three_tokens() -> None:
-    """Device flow returns (x_token, music_token, refresh_token)."""
-    session = _make_device_session()
-    creds = _make_credentials()
-    mock_client = mock.AsyncMock()
-    mock_client.start_device_login.return_value = session
-    mock_client.poll_device_until_confirmed.return_value = creds
-
-    mock_mass = _make_mass()
-    mock_auth_helper = mock.AsyncMock()
-
-    with _patched_flow(mock_client, mock_auth_helper):
-        x_token, music_token, refresh_token = await perform_device_auth(mock_mass, "session_1")
-
-    assert x_token == "test_x_token"
-    assert music_token == "test_music_token"
-    assert refresh_token == "test_refresh_token"
-    mock_client.start_device_login.assert_awaited_once()
-    mock_client.poll_device_until_confirmed.assert_awaited_once_with(session, total_timeout=None)
-
-
-async def test_perform_device_auth_serves_intermediate_page_and_cleans_up() -> None:
-    """A temporary HTML page + status endpoint are registered and unregistered after."""
-    session = _make_device_session(
-        user_code="WXYZ-9999",
-        verification_url="https://oauth.yandex.ru/device",
-    )
-    creds = _make_credentials()
-    mock_client = mock.AsyncMock()
-    mock_client.start_device_login.return_value = session
-    mock_client.poll_device_until_confirmed.return_value = creds
-
-    mock_mass = _make_mass()
-    mock_auth_helper = mock.AsyncMock()
-
-    with _patched_flow(mock_client, mock_auth_helper):
-        await perform_device_auth(mock_mass, "session_1")
-
-    # Route teardown is deferred to a background task (grace period for the
-    # page's final status poll) — drain it before asserting unregistration.
-    await _drain_background_tasks()
-
-    expected_path = "/yandex_music/device_code/session_1"
-    expected_status_path = f"{expected_path}/status"
-
-    registered_paths = [
-        (c.args[0], c.args[2]) for c in mock_mass.webserver.register_dynamic_route.call_args_list
-    ]
-    assert (expected_path, "GET") in registered_paths
-    assert (expected_status_path, "GET") in registered_paths
-
-    unregistered_paths = [
-        c.args for c in mock_mass.webserver.unregister_dynamic_route.call_args_list
-    ]
-    assert (expected_path, "GET") in unregistered_paths
-    assert (expected_status_path, "GET") in unregistered_paths
-
-    mock_auth_helper.__aenter__.return_value.send_url.assert_called_once_with(
-        f"http://ma.local:8095{expected_path}"
-    )
-
-
-async def test_perform_device_auth_status_endpoint_reports_done_after_success() -> None:
-    """
-    The status endpoint reports state=done after the device flow completes.
-
-    Without this the popup window (opened via target=_blank) has no signal to
-    close itself after the user confirms the code.
-    """
-    session = _make_device_session()
-    creds = _make_credentials()
-    mock_client = mock.AsyncMock()
-    mock_client.start_device_login.return_value = session
-    mock_client.poll_device_until_confirmed.return_value = creds
-
-    mock_mass = _make_mass()
-    mock_auth_helper = mock.AsyncMock()
-
-    with _patched_flow(mock_client, mock_auth_helper):
-        await perform_device_auth(mock_mass, "session_xyz")
-
-    status_call = next(
-        c
-        for c in mock_mass.webserver.register_dynamic_route.call_args_list
-        if c.args[0].endswith("/status")
-    )
-    status_handler = status_call.args[1]
-    response = await status_handler(mock.MagicMock())
-    assert isinstance(response.body, bytes)
-    payload = json.loads(response.body)
-    assert payload["state"] == "done"
-
-
-async def test_perform_device_auth_returns_without_grace_delay(
-    skip_grace_sleep: mock.AsyncMock,
-) -> None:
-    """
-    The flow returns as soon as auth completes — the grace period must not block it.
-
-    The grace sleep is made to hang forever: the caller must still get its
-    tokens immediately, while the routes stay registered until the deferred
-    teardown finally runs.
-    """
-    release = asyncio.Event()
-
-    async def _hang(*_args: object, **_kwargs: object) -> None:
-        await release.wait()
-
-    skip_grace_sleep.side_effect = _hang
-
-    session = _make_device_session()
-    creds = _make_credentials()
-    mock_client = mock.AsyncMock()
-    mock_client.start_device_login.return_value = session
-    mock_client.poll_device_until_confirmed.return_value = creds
-
-    webserver = _FakeWebserver()
-    mock_mass = _make_mass(webserver)
-    mock_auth_helper = mock.AsyncMock()
-
-    with _patched_flow(mock_client, mock_auth_helper):
-        tokens = await asyncio.wait_for(perform_device_auth(mock_mass, "session_1"), timeout=1.0)
-
-    assert tokens == ("test_x_token", "test_music_token", "test_refresh_token")
-    # Teardown is still pending — the page can keep polling the final state.
-    assert ("/yandex_music/device_code/session_1", "GET") in webserver.routes
-    assert ("/yandex_music/device_code/session_1/status", "GET") in webserver.routes
-
-    release.set()
-    await _drain_background_tasks()
-    assert webserver.routes == {}
-
-
-async def test_perform_device_auth_immediate_retry_reuses_session_path(
-    skip_grace_sleep: mock.AsyncMock,
-) -> None:
-    """
-    A retry with the same session id must succeed while teardown is still pending.
-
-    The MA frontend can reuse the config-flow session id for a rapid second
-    login attempt; the previous attempt's routes (awaiting their grace-period
-    teardown) must be taken over, not collide with a RuntimeError.
-    """
-    release = asyncio.Event()
-
-    async def _hang(*_args: object, **_kwargs: object) -> None:
-        await release.wait()
-
-    skip_grace_sleep.side_effect = _hang
-
-    session = _make_device_session()
-    creds = _make_credentials()
-    webserver = _FakeWebserver()
-    mock_mass = _make_mass(webserver)
-
-    try:
-        for _attempt in range(2):
-            mock_client = mock.AsyncMock()
-            mock_client.start_device_login.return_value = session
-            mock_client.poll_device_until_confirmed.return_value = creds
-            mock_auth_helper = mock.AsyncMock()
-            with _patched_flow(mock_client, mock_auth_helper):
-                tokens = await perform_device_auth(mock_mass, "session_retry")
-            assert tokens[0] == "test_x_token"
-    finally:
-        release.set()
-
-    await _drain_background_tasks()
-    assert webserver.routes == {}
-
-
-async def test_route_teardown_attempts_every_path_despite_errors() -> None:
-    """
-    A failing unregister for one route must not skip the remaining routes.
-
-    Teardown runs in a detached task (e.g. during MA shutdown the webserver
-    may already be gone) — one failure must not leak the other route or
-    surface as an unretrieved task exception.
-    """
-    session = _make_device_session()
-    creds = _make_credentials()
-    mock_client = mock.AsyncMock()
-    mock_client.start_device_login.return_value = session
-    mock_client.poll_device_until_confirmed.return_value = creds
-
-    webserver = _FakeWebserver()
-    mock_mass = _make_mass(webserver)
-    mock_auth_helper = mock.AsyncMock()
-
-    with _patched_flow(mock_client, mock_auth_helper):
-        await perform_device_auth(mock_mass, "session_err")
-
-    webserver.unregister_error = RuntimeError("Dynamic routes are not enabled")
-    baseline = len(webserver.unregister_calls)
-    await _drain_background_tasks()
-    assert len(webserver.unregister_calls) - baseline == 2
-
-
-async def test_device_code_page_countdown_reflects_elapsed_time() -> None:
-    """
-    The countdown shows the time actually left, not the full code lifetime.
-
-    The popup can open (or be reloaded) long after the code was issued; the
-    page must be rendered with the remaining seconds at request time.
-    """
-    session = _make_device_session(expires_in=543)
-    fake_time = mock.MagicMock()
-    fake_time.monotonic.side_effect = [1000.0, 1100.0]
-    with mock.patch("ya_passport_auth.ma.routes.time", fake_time, create=True):
-        body = await _render_device_page(_make_page_mass(), session=session)
-    assert "443" in body
-
-
-@pytest.mark.parametrize(
-    ("exc", "expected_reason", "expected_match"),
-    [
-        (DeviceCodeTimeoutError("expired"), "expired", "timed out"),
-        (InvalidCredentialsError("denied"), "denied", "denied"),
-        (YaPassportError("boom"), "error", "Device authentication failed"),
-    ],
-    ids=["expired", "denied", "error"],
-)
-async def test_perform_device_auth_status_reports_failure_reason(
-    exc: Exception, expected_reason: str, expected_match: str
-) -> None:
-    """
-    When poll fails, the status endpoint reports failed plus a machine-readable reason.
-
-    The page uses the reason to tell the user what to do next — an expired
-    code and a rejected login require different actions.
-    """
-    session = _make_device_session()
-    mock_client = mock.AsyncMock()
-    mock_client.start_device_login.return_value = session
-    mock_client.poll_device_until_confirmed.side_effect = exc
-
-    mock_mass = _make_mass()
-    mock_auth_helper = mock.AsyncMock()
-
-    status_handlers: list[Callable[[web.Request], Awaitable[web.Response]]] = []
-
-    def _capture(
-        path: str,
-        handler: Callable[[web.Request], Awaitable[web.Response]],
-        _method: str,
-    ) -> None:
-        if path.endswith("/status"):
-            status_handlers.append(handler)
-
-    mock_mass.webserver.register_dynamic_route.side_effect = _capture
-
-    with (
-        _patched_flow(mock_client, mock_auth_helper),
-        pytest.raises(LoginFailed, match=expected_match),
-    ):
-        await perform_device_auth(mock_mass, "session_fail")
-
-    assert status_handlers, "status handler should have been registered"
-    response = await status_handlers[0](mock.MagicMock())
-    assert isinstance(response.body, bytes)
-    payload = json.loads(response.body)
-    assert payload == {"state": "failed", "reason": expected_reason}
-    await _drain_background_tasks()
-
-
-async def test_perform_device_auth_does_not_mark_cancellation_as_failure() -> None:
-    """
-    CancelledError must propagate without marking state as 'failed'.
-
-    Routes must still be torn down eventually so a cancelled login doesn't
-    leak webserver routes.
-    """
-    session = _make_device_session()
-    mock_client = mock.AsyncMock()
-    mock_client.start_device_login.return_value = session
-    mock_client.poll_device_until_confirmed.side_effect = asyncio.CancelledError()
-
-    mock_mass = _make_mass()
-    mock_auth_helper = mock.AsyncMock()
-
-    status_handlers: list[Callable[[web.Request], Awaitable[web.Response]]] = []
-
-    def _capture(
-        path: str,
-        handler: Callable[[web.Request], Awaitable[web.Response]],
-        _method: str,
-    ) -> None:
-        if path.endswith("/status"):
-            status_handlers.append(handler)
-
-    mock_mass.webserver.register_dynamic_route.side_effect = _capture
-
-    with _patched_flow(mock_client, mock_auth_helper), pytest.raises(asyncio.CancelledError):
-        await perform_device_auth(mock_mass, "session_cancel")
-
-    assert status_handlers, "status handler should have been registered"
-    response = await status_handlers[0](mock.MagicMock())
-    assert isinstance(response.body, bytes)
-    payload = json.loads(response.body)
-    assert payload["state"] == "pending"
-
-    await _drain_background_tasks()
-    unregistered = [c.args for c in mock_mass.webserver.unregister_dynamic_route.call_args_list]
-    assert ("/yandex_music/device_code/session_cancel", "GET") in unregistered
-    assert ("/yandex_music/device_code/session_cancel/status", "GET") in unregistered
-
-
-async def test_perform_device_auth_route_handler_renders_code_and_url() -> None:
-    """The registered route handler returns HTML containing the code + verification URL."""
-    session = _make_device_session(
-        user_code="ABCD-1234",
-        verification_url="https://oauth.yandex.ru/device",
-    )
-    creds = _make_credentials()
-    mock_client = mock.AsyncMock()
-    mock_client.start_device_login.return_value = session
-    mock_client.poll_device_until_confirmed.return_value = creds
-
-    mock_mass = _make_mass()
-    mock_auth_helper = mock.AsyncMock()
-
-    with _patched_flow(mock_client, mock_auth_helper):
-        await perform_device_auth(mock_mass, "session_1")
-
-    page_call = next(
-        c
-        for c in mock_mass.webserver.register_dynamic_route.call_args_list
-        if not c.args[0].endswith("/status")
-    )
-    handler = page_call.args[1]
-    response = await handler(mock.MagicMock())
-    body = response.text
-    assert body is not None
-    assert "ABCD-1234" in body
-    assert "https://oauth.yandex.ru/device" in body
-    assert response.content_type == "text/html"
-
-
-async def test_perform_device_auth_timeout_raises_login_failed() -> None:
-    """DeviceCodeTimeoutError from library is mapped to LoginFailed and the route is freed."""
-    session = _make_device_session()
-    mock_client = mock.AsyncMock()
-    mock_client.start_device_login.return_value = session
-    mock_client.poll_device_until_confirmed.side_effect = DeviceCodeTimeoutError("expired")
-
-    mock_mass = _make_mass()
-    mock_auth_helper = mock.AsyncMock()
-
-    with (
-        _patched_flow(mock_client, mock_auth_helper),
-        pytest.raises(LoginFailed, match="timed out"),
-    ):
-        await perform_device_auth(mock_mass, "session_1")
-
-    await _drain_background_tasks()
-    unregistered_paths = [
-        c.args for c in mock_mass.webserver.unregister_dynamic_route.call_args_list
-    ]
-    assert ("/yandex_music/device_code/session_1", "GET") in unregistered_paths
-    assert ("/yandex_music/device_code/session_1/status", "GET") in unregistered_paths
-
-
-async def test_perform_device_auth_ya_passport_error_raises_login_failed() -> None:
-    """Generic YaPassportError from library is mapped to LoginFailed."""
-    mock_client = mock.AsyncMock()
-    mock_client.start_device_login.side_effect = YaPassportError("misc")
-
-    mock_mass = _make_mass()
-    mock_auth_helper = mock.AsyncMock()
-
-    with (
-        _patched_flow(mock_client, mock_auth_helper),
-        pytest.raises(LoginFailed, match="Device authentication failed"),
-    ):
-        await perform_device_auth(mock_mass, "session_1")
-
-
-async def test_perform_device_auth_no_music_token_raises_login_failed() -> None:
-    """Credentials without music_token raises LoginFailed."""
-    session = _make_device_session()
-    creds = _make_credentials(music_token=None)
-    mock_client = mock.AsyncMock()
-    mock_client.start_device_login.return_value = session
-    mock_client.poll_device_until_confirmed.return_value = creds
-
-    mock_mass = _make_mass()
-    mock_auth_helper = mock.AsyncMock()
-
-    with (
-        _patched_flow(mock_client, mock_auth_helper),
-        pytest.raises(LoginFailed, match="no music token"),
-    ):
-        await perform_device_auth(mock_mass, "session_1")
-
-
-async def test_perform_device_auth_no_refresh_token_raises_login_failed() -> None:
-    """Credentials without refresh_token raises LoginFailed."""
-    session = _make_device_session()
-    creds = _make_credentials(refresh_token=None)
-    mock_client = mock.AsyncMock()
-    mock_client.start_device_login.return_value = session
-    mock_client.poll_device_until_confirmed.return_value = creds
-
-    mock_mass = _make_mass()
-    mock_auth_helper = mock.AsyncMock()
-
-    with (
-        _patched_flow(mock_client, mock_auth_helper),
-        pytest.raises(LoginFailed, match="no refresh token"),
-    ):
-        await perform_device_auth(mock_mass, "session_1")
-
-
-# -- device-code page content ---------------------------------------------------
-
-
-def _make_page_mass(locale: object = None) -> mock.MagicMock:
-    """Build a mass mock for page-rendering tests, optionally with a locale."""
-    mock_mass = _make_mass()
-    if locale is not None:
-        mock_mass.metadata.locale = locale
-    return mock_mass
-
-
-async def test_device_code_page_copy_targets_code_block() -> None:
-    """
-    The code block itself is the copy target; no standalone copy button.
-
-    ``document.execCommand`` must be present as the fallback because the
-    Clipboard API is unavailable on plain-HTTP MA deployments.
-    """
-    body = await _render_device_page(_make_page_mass())
-    assert 'id="copy"' not in body
-    assert "execCommand" in body
-    assert 'role="button"' in body
-
-
-async def test_device_code_page_shows_countdown_and_terminal_states() -> None:
-    """The page embeds the code lifetime and treats a 404 status as terminal."""
-    session = _make_device_session(expires_in=543)
-    body = await _render_device_page(_make_page_mass(), session=session)
-    assert "543" in body
-    assert "404" in body
-
-
-async def test_device_code_page_shows_verification_url_as_text() -> None:
-    """The verification URL is visible as text, not only hidden in the link href."""
-    body = await _render_device_page(_make_page_mass())
-    assert body.count("https://oauth.yandex.ru/device") >= 2
-
-
-async def test_device_code_page_localized_russian() -> None:
-    """A Russian MA locale renders the page in Russian."""
-    body = await _render_device_page(_make_page_mass(locale="ru_RU"))
-    assert 'lang="ru"' in body
-    assert "Скопируйте" in body
-
-
-async def test_device_code_page_defaults_to_english_for_unknown_locale() -> None:
-    """A non-string locale (or non-Russian) falls back to English."""
-    body = await _render_device_page(_make_page_mass(locale=mock.MagicMock()))
-    assert 'lang="en"' in body
-    assert "Tap the code" in body
-    assert "Скопируйте" not in body
-
-
-async def test_device_code_page_supports_dark_theme() -> None:
-    """The page adapts to the user's dark colour scheme."""
-    body = await _render_device_page(_make_page_mass())
-    assert "prefers-color-scheme: dark" in body
-
-
-async def test_device_code_page_uses_translated_strings() -> None:
-    """Strings resolved by the MA translations controller reach the page."""
-    mock_mass = _make_page_mass(locale="de_DE")
-    mock_mass.translations.ensure_locale_loaded = mock.AsyncMock()
-    mock_mass.translations.get_translation = mock.Mock(
-        side_effect=lambda key, **_kw: (
-            "Anmeldung bei Yandex Music" if key.endswith(".title") else None
-        )
-    )
-    body = await _render_device_page(mock_mass)
-    assert "Anmeldung bei Yandex Music" in body
-
-
-async def test_device_code_page_falls_back_without_translation() -> None:
-    """Unresolved keys fall back to the in-code table in the page language."""
-    mock_mass = _make_page_mass(locale="ru_RU")
-    mock_mass.translations.ensure_locale_loaded = mock.AsyncMock()
-    mock_mass.translations.get_translation = mock.Mock(return_value=None)
-    body = await _render_device_page(mock_mass)
-    assert "Скопируйте" in body
-
-
-async def test_device_code_page_survives_missing_translations_controller() -> None:
-    """An MA build without the translations controller renders the page as today."""
-    mock_mass = _make_page_mass()
-    del mock_mass.translations
-    body = await _render_device_page(mock_mass)
-    assert "Tap the code" in body
-
-
-# -- perform_qr_auth ----------------------------------------------------------
-
-
-async def test_perform_qr_auth_success() -> None:
-    """QR flow returns (x_token, music_token) as plain strings."""
-    qr = _make_qr_session()
-    creds = _make_credentials()
-    mock_client = mock.AsyncMock()
-    mock_client.start_qr_login.return_value = qr
-    mock_client.poll_qr_until_confirmed.return_value = creds
-
-    mock_mass = _make_mass()
-    mock_auth_helper = mock.AsyncMock()
-
-    with _patched_flow(mock_client, mock_auth_helper):
-        x_token, music_token = await perform_qr_auth(mock_mass, "session_1")
-
-    assert x_token == "test_x_token"
-    assert music_token == "test_music_token"
-    mock_client.start_qr_login.assert_awaited_once()
-    mock_client.poll_qr_until_confirmed.assert_awaited_once_with(qr)
-
-
-async def test_perform_qr_auth_sends_qr_url() -> None:
-    """QR URL is sent to the AuthenticationHelper."""
-    qr = _make_qr_session()
-    creds = _make_credentials()
-    mock_client = mock.AsyncMock()
-    mock_client.start_qr_login.return_value = qr
-    mock_client.poll_qr_until_confirmed.return_value = creds
-
-    mock_mass = _make_mass()
-    mock_auth_helper = mock.AsyncMock()
-
-    with _patched_flow(mock_client, mock_auth_helper):
-        await perform_qr_auth(mock_mass, "session_1")
-
-    mock_auth_helper.__aenter__.return_value.send_url.assert_called_once_with(qr.qr_url)
-
-
-async def test_perform_qr_auth_timeout_raises_login_failed() -> None:
-    """QRTimeoutError from library is mapped to LoginFailed."""
-    qr = _make_qr_session()
-    mock_client = mock.AsyncMock()
-    mock_client.start_qr_login.return_value = qr
-    mock_client.poll_qr_until_confirmed.side_effect = QRTimeoutError("timed out")
-
-    mock_mass = _make_mass()
-    mock_auth_helper = mock.AsyncMock()
-
-    with (
-        _patched_flow(mock_client, mock_auth_helper),
-        pytest.raises(LoginFailed, match="timed out"),
-    ):
-        await perform_qr_auth(mock_mass, "session_1")
-
-
-async def test_perform_qr_auth_passport_error_raises_login_failed() -> None:
-    """Generic YaPassportError is mapped to LoginFailed."""
-    mock_client = mock.AsyncMock()
-    mock_client.start_qr_login.side_effect = YaPassportError("misc")
-
-    mock_mass = _make_mass()
-    mock_auth_helper = mock.AsyncMock()
-
-    with (
-        _patched_flow(mock_client, mock_auth_helper),
-        pytest.raises(LoginFailed, match="QR authentication failed"),
-    ):
-        await perform_qr_auth(mock_mass, "session_1")
-
-
-async def test_perform_qr_auth_no_music_token_raises() -> None:
-    """Credentials without music_token raises LoginFailed."""
-    qr = _make_qr_session()
-    creds = _make_credentials(music_token=None)
-    mock_client = mock.AsyncMock()
-    mock_client.start_qr_login.return_value = qr
-    mock_client.poll_qr_until_confirmed.return_value = creds
-
-    mock_mass = _make_mass()
-    mock_auth_helper = mock.AsyncMock()
-
-    with (
-        _patched_flow(mock_client, mock_auth_helper),
-        pytest.raises(LoginFailed, match="no music token"),
-    ):
-        await perform_qr_auth(mock_mass, "session_1")
-
-
-# -- refresh_music_token -------------------------------------------------------
 
 
 async def test_refresh_music_token_success() -> None:
@@ -843,9 +84,6 @@ async def test_refresh_music_token_transient_error_raises_temporarily_unavailabl
             await refresh_music_token(SecretStr("my_x_token"))
 
 
-# -- validate_x_token ----------------------------------------------------------
-
-
 async def test_validate_x_token_valid() -> None:
     """Valid x_token returns True."""
     mock_client = mock.AsyncMock()
@@ -863,7 +101,7 @@ async def test_validate_x_token_valid() -> None:
 
 
 async def test_validate_x_token_invalid_returns_false() -> None:
-    """A terminal credential error returns False (token rejected by Passport)."""
+    """A terminal credential error returns False."""
     mock_client = mock.AsyncMock()
     mock_client.validate_x_token.side_effect = InvalidCredentialsError("token rejected")
 
@@ -884,12 +122,7 @@ async def test_validate_x_token_invalid_returns_false() -> None:
     ids=["network", "rate_limited"],
 )
 async def test_validate_x_token_transient_error_propagates(exc: Exception) -> None:
-    """
-    Transient Passport failures must not masquerade as "token invalid".
-
-    A network blip or 429 should not cause callers to clear the stored
-    credential — re-raise so the caller can distinguish the two.
-    """
+    """Transient failures are distinguishable from invalid credentials."""
     mock_client = mock.AsyncMock()
     mock_client.validate_x_token.side_effect = exc
 
@@ -903,11 +136,8 @@ async def test_validate_x_token_transient_error_propagates(exc: Exception) -> No
             await validate_x_token(SecretStr("some_token"))
 
 
-# -- refresh_credentials_via_passport ------------------------------------------
-
-
 async def test_refresh_credentials_via_passport_success() -> None:
-    """Successful refresh returns full Credentials triple."""
+    """Successful refresh returns the full credential triple."""
     new_creds = _make_credentials(
         x_token="new_x",
         music_token="new_music",
@@ -954,10 +184,10 @@ async def test_refresh_credentials_via_passport_error_raises_login_failed() -> N
     [PassportNetworkError("offline"), RateLimitedError("429")],
     ids=["network", "rate_limited"],
 )
-async def test_refresh_credentials_via_passport_transient_error_raises_temporarily_unavailable(
+async def test_refresh_credentials_via_passport_transient_error_is_temporary(
     exc: Exception,
 ) -> None:
-    """Transient Passport failures don't masquerade as LoginFailed."""
+    """Transient credential refresh failures remain retryable."""
     mock_client = mock.AsyncMock()
     mock_client.refresh_credentials.side_effect = exc
 
@@ -971,49 +201,7 @@ async def test_refresh_credentials_via_passport_transient_error_raises_temporari
             await refresh_credentials_via_passport(SecretStr("x"), SecretStr("refresh"))
 
 
-# -- exception-message redaction ----------------------------------------------
-#
-# These tests guard against leaking the upstream ``ya-passport-auth`` exception
-# payload into our own ``LoginFailed`` / ``ResourceTemporarilyUnavailable``
-# messages. The library may include token fragments, device codes, or raw
-# response bodies in its exception text — none of which should reach MA logs
-# or the frontend.
-
 _SECRET_PAYLOAD = "token=ABC_TOKEN_LEAK&csrf=xyz"
-
-
-async def test_perform_device_auth_error_does_not_leak_library_payload() -> None:
-    """Errors raised from device-flow must not include library str()."""
-    mock_client = mock.AsyncMock()
-    mock_client.start_device_login.side_effect = PassportNetworkError(_SECRET_PAYLOAD)
-    mock_mass = _make_mass()
-    mock_auth_helper = mock.AsyncMock()
-
-    with (
-        _patched_flow(mock_client, mock_auth_helper),
-        pytest.raises(ResourceTemporarilyUnavailable) as exc_info,
-    ):
-        await perform_device_auth(mock_mass, "session_1")
-
-    assert _SECRET_PAYLOAD not in str(exc_info.value)
-    assert "ABC_TOKEN_LEAK" not in str(exc_info.value)
-
-
-async def test_perform_qr_auth_error_does_not_leak_library_payload() -> None:
-    """Errors raised from QR flow must not include library str()."""
-    mock_client = mock.AsyncMock()
-    mock_client.start_qr_login.side_effect = PassportNetworkError(_SECRET_PAYLOAD)
-    mock_mass = _make_mass()
-    mock_auth_helper = mock.AsyncMock()
-
-    with (
-        _patched_flow(mock_client, mock_auth_helper),
-        pytest.raises(ResourceTemporarilyUnavailable) as exc_info,
-    ):
-        await perform_qr_auth(mock_mass, "session_1")
-
-    assert _SECRET_PAYLOAD not in str(exc_info.value)
-    assert "ABC_TOKEN_LEAK" not in str(exc_info.value)
 
 
 @pytest.mark.parametrize(
@@ -1028,7 +216,7 @@ async def test_perform_qr_auth_error_does_not_leak_library_payload() -> None:
 async def test_refresh_music_token_error_does_not_leak_library_payload(
     exc: Exception, expected_exc_type: type[Exception]
 ) -> None:
-    """``refresh_music_token`` exceptions must not include library str()."""
+    """Music-token refresh errors redact upstream payloads."""
     mock_client = mock.AsyncMock()
     mock_client.refresh_music_token.side_effect = exc
 
@@ -1054,10 +242,10 @@ async def test_refresh_music_token_error_does_not_leak_library_payload(
     ],
     ids=["network", "rate_limited", "invalid_credentials"],
 )
-async def test_refresh_credentials_via_passport_error_does_not_leak_library_payload(
+async def test_refresh_credentials_error_does_not_leak_library_payload(
     exc: Exception, expected_exc_type: type[Exception]
 ) -> None:
-    """``refresh_credentials_via_passport`` exceptions must not include library str()."""
+    """Credential refresh errors redact upstream payloads."""
     mock_client = mock.AsyncMock()
     mock_client.refresh_credentials.side_effect = exc
 

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -7,31 +7,30 @@ from unittest import mock
 
 from music_assistant.providers.yandex_music import get_config_entries
 from music_assistant.providers.yandex_music.constants import (
-    CONF_ACTION_AUTH_DEVICE,
-    CONF_SESSION_ID,
+    CONF_ACTION_CLEAR_AUTH,
+    CONF_REFRESH_TOKEN,
+    CONF_TOKEN,
+    CONF_X_TOKEN,
 )
 
 if TYPE_CHECKING:
     from music_assistant_models.config_entries import ConfigValueType
 
 
-async def test_get_config_entries_label_prompts_save_after_auth() -> None:
-    """
-    After a successful login action, the label must warn about the Save step.
+async def test_get_config_entries_uses_manual_token_without_popup_actions() -> None:
+    """Expose manual token setup while retaining stored refresh credentials."""
+    values: dict[str, ConfigValueType] = {
+        CONF_X_TOKEN: "stored-x",
+        CONF_REFRESH_TOKEN: "stored-refresh",
+    }
 
-    Tokens live only in the dialog values until the user hits Save — a missed
-    Save silently discards the whole login.
-    """
-    mock_mass = mock.MagicMock()
-    values: dict[str, ConfigValueType] = {CONF_SESSION_ID: "sess-1"}
+    entries = await get_config_entries(mock.MagicMock(), None, None, values)
+    by_key = {entry.key: entry for entry in entries}
 
-    with mock.patch(
-        "music_assistant.providers.yandex_music.perform_device_auth",
-        new=mock.AsyncMock(return_value=("x_tok", "music_tok", "refresh_tok")),
-    ):
-        entries = await get_config_entries(mock_mass, None, CONF_ACTION_AUTH_DEVICE, values)
-
-    label = next(e for e in entries if e.key == "label_text")
-    assert label.label is not None
-    assert label.label.startswith("⚠")
-    assert "Save" in label.label
+    assert "auth_device" not in by_key
+    assert "auth_qr" not in by_key
+    assert "remember_session" not in by_key
+    assert CONF_TOKEN in by_key
+    assert CONF_ACTION_CLEAR_AUTH in by_key
+    assert by_key[CONF_X_TOKEN].value == "stored-x"
+    assert by_key[CONF_REFRESH_TOKEN].value == "stored-refresh"

--- a/tests/test_localization.py
+++ b/tests/test_localization.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, cast
 from unittest import mock
 
 from music_assistant.providers.yandex_music import get_config_entries
-from music_assistant.providers.yandex_music.auth import PAGE_CONFIG
 from music_assistant.providers.yandex_music.constants import (
     QUALITY_BALANCED,
     QUALITY_EFFICIENT,
@@ -38,13 +37,8 @@ def _load_strings() -> dict[str, dict[str, object]]:
 
 
 async def _get_entries() -> tuple[ConfigEntry, ...]:
-    """Collect config entries with auth flows stubbed out."""
-    mock_mass = mock.MagicMock()
-    with mock.patch(
-        "music_assistant.providers.yandex_music.perform_device_auth",
-        new=mock.AsyncMock(return_value=("x", "m", "r")),
-    ):
-        return await get_config_entries(mock_mass, None, None, {})
+    """Collect config entries."""
+    return await get_config_entries(mock.MagicMock(), None, None, {})
 
 
 async def test_strings_json_covers_config_entries() -> None:
@@ -94,45 +88,6 @@ async def test_quality_options_use_value_first_signature() -> None:
         QUALITY_HIGH,
         QUALITY_SUPERB,
     }
-
-
-async def test_auth_status_label_localized_via_translation_key() -> None:
-    """
-    The dynamic auth status label carries a per-state translation key.
-
-    The post-login "click Save" warning (spec 0002) must be authored in
-    strings.json so Lokalise localizes it like everything else.
-    """
-    strings = _load_strings()
-    mock_mass = mock.MagicMock()
-    with mock.patch(
-        "music_assistant.providers.yandex_music.perform_device_auth",
-        new=mock.AsyncMock(return_value=("x", "m", "r")),
-    ):
-        entries = await get_config_entries(mock_mass, None, "auth_device", {"session_id": "s1"})
-    label = next(e for e in entries if e.key == "label_text")
-    assert label.translation_key is not None
-    authored = strings["config_entries"][label.translation_key]
-    assert isinstance(authored, dict)
-    assert "label" in authored
-
-
-async def test_strings_json_authors_device_page_keys() -> None:
-    """
-    Every device-code page string is authored under page.device_code.
-
-    The HTML ``lang`` attribute is presentation plumbing, not a
-    translatable string, so it stays code-side.
-    """
-    strings = _load_strings()
-    page = strings["page"]
-    assert isinstance(page, dict)
-    authored = page["device_code"]
-    assert isinstance(authored, dict)
-    # "context" is the optional provider paragraph — unused (empty) for this
-    # provider, so it is not authored in strings.json either.
-    expected = set(PAGE_CONFIG.strings_for("en")) - {"lang", "context"}
-    assert set(authored) == expected
 
 
 def _media_label_provider(authored: str | None) -> mock.MagicMock:

--- a/uv.lock
+++ b/uv.lock
@@ -912,9 +912,9 @@ requires-dist = [
     { name = "pytest-aiohttp", marker = "extra == 'test'", specifier = ">=1.1" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.24" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=7.0" },
-    { name = "ruff", marker = "extra == 'test'", specifier = ">=0.14,<0.15" },
+    { name = "ruff", marker = "extra == 'test'", specifier = ">=0.15,<0.16" },
     { name = "syrupy", marker = "extra == 'test'", specifier = ">=5.0" },
-    { name = "ya-passport-auth", extras = ["ma"], specifier = "==1.7.0" },
+    { name = "ya-passport-auth", extras = ["ma"], specifier = "==1.8.0" },
     { name = "yandex-music", specifier = "==3.0.0" },
 ]
 provides-extras = ["test"]
@@ -1723,28 +1723,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.14.13"
+version = "0.15.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/50/0a/1914efb7903174b381ee2ffeebb4253e729de57f114e63595114c8ca451f/ruff-0.14.13.tar.gz", hash = "sha256:83cd6c0763190784b99650a20fec7633c59f6ebe41c5cc9d45ee42749563ad47", size = 6059504, upload-time = "2026-01-15T20:15:16.918Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/06/ae069393fc66e8ff33036d4b368003833bf6e88ccf182e17e7a2f1c754fd/ruff-0.15.22.tar.gz", hash = "sha256:3f15175b1fb580126f58285a5dae6b2ea89000136d980c64499211f116b54809", size = 4785063, upload-time = "2026-07-16T15:14:13.244Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/ae/0deefbc65ca74b0ab1fd3917f94dc3b398233346a74b8bbb0a916a1a6bf6/ruff-0.14.13-py3-none-linux_armv6l.whl", hash = "sha256:76f62c62cd37c276cb03a275b198c7c15bd1d60c989f944db08a8c1c2dbec18b", size = 13062418, upload-time = "2026-01-15T20:14:50.779Z" },
-    { url = "https://files.pythonhosted.org/packages/47/df/5916604faa530a97a3c154c62a81cb6b735c0cb05d1e26d5ad0f0c8ac48a/ruff-0.14.13-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:914a8023ece0528d5cc33f5a684f5f38199bbb566a04815c2c211d8f40b5d0ed", size = 13442344, upload-time = "2026-01-15T20:15:07.94Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/f3/e0e694dd69163c3a1671e102aa574a50357536f18a33375050334d5cd517/ruff-0.14.13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d24899478c35ebfa730597a4a775d430ad0d5631b8647a3ab368c29b7e7bd063", size = 12354720, upload-time = "2026-01-15T20:15:09.854Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/e8/67f5fcbbaee25e8fc3b56cc33e9892eca7ffe09f773c8e5907757a7e3bdb/ruff-0.14.13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9aaf3870f14d925bbaf18b8a2347ee0ae7d95a2e490e4d4aea6813ed15ebc80e", size = 12774493, upload-time = "2026-01-15T20:15:20.908Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/ce/d2e9cb510870b52a9565d885c0d7668cc050e30fa2c8ac3fb1fda15c083d/ruff-0.14.13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac5b7f63dd3b27cc811850f5ffd8fff845b00ad70e60b043aabf8d6ecc304e09", size = 12815174, upload-time = "2026-01-15T20:15:05.74Z" },
-    { url = "https://files.pythonhosted.org/packages/88/00/c38e5da58beebcf4fa32d0ddd993b63dfacefd02ab7922614231330845bf/ruff-0.14.13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:78d2b1097750d90ba82ce4ba676e85230a0ed694178ca5e61aa9b459970b3eb9", size = 13680909, upload-time = "2026-01-15T20:15:14.537Z" },
-    { url = "https://files.pythonhosted.org/packages/61/61/cd37c9dd5bd0a3099ba79b2a5899ad417d8f3b04038810b0501a80814fd7/ruff-0.14.13-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:7d0bf87705acbbcb8d4c24b2d77fbb73d40210a95c3903b443cd9e30824a5032", size = 15144215, upload-time = "2026-01-15T20:15:22.886Z" },
-    { url = "https://files.pythonhosted.org/packages/56/8a/85502d7edbf98c2df7b8876f316c0157359165e16cdf98507c65c8d07d3d/ruff-0.14.13-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a3eb5da8e2c9e9f13431032fdcbe7681de9ceda5835efee3269417c13f1fed5c", size = 14706067, upload-time = "2026-01-15T20:14:48.271Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/2f/de0df127feb2ee8c1e54354dc1179b4a23798f0866019528c938ba439aca/ruff-0.14.13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:642442b42957093811cd8d2140dfadd19c7417030a7a68cf8d51fcdd5f217427", size = 14133916, upload-time = "2026-01-15T20:14:57.357Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/77/9b99686bb9fe07a757c82f6f95e555c7a47801a9305576a9c67e0a31d280/ruff-0.14.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4acdf009f32b46f6e8864af19cbf6841eaaed8638e65c8dac845aea0d703c841", size = 13859207, upload-time = "2026-01-15T20:14:55.111Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/46/2bdcb34a87a179a4d23022d818c1c236cb40e477faf0d7c9afb6813e5876/ruff-0.14.13-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:591a7f68860ea4e003917d19b5c4f5ac39ff558f162dc753a2c5de897fd5502c", size = 14043686, upload-time = "2026-01-15T20:14:52.841Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/a9/5c6a4f56a0512c691cf143371bcf60505ed0f0860f24a85da8bd123b2bf1/ruff-0.14.13-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:774c77e841cc6e046fc3e91623ce0903d1cd07e3a36b1a9fe79b81dab3de506b", size = 12663837, upload-time = "2026-01-15T20:15:18.921Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/bb/b920016ece7651fa7fcd335d9d199306665486694d4361547ccb19394c44/ruff-0.14.13-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:61f4e40077a1248436772bb6512db5fc4457fe4c49e7a94ea7c5088655dd21ae", size = 12805867, upload-time = "2026-01-15T20:14:59.272Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/b3/0bd909851e5696cd21e32a8fc25727e5f58f1934b3596975503e6e85415c/ruff-0.14.13-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6d02f1428357fae9e98ac7aa94b7e966fd24151088510d32cf6f902d6c09235e", size = 13208528, upload-time = "2026-01-15T20:15:03.732Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/3b/e2d94cb613f6bbd5155a75cbe072813756363eba46a3f2177a1fcd0cd670/ruff-0.14.13-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e399341472ce15237be0c0ae5fbceca4b04cd9bebab1a2b2c979e015455d8f0c", size = 13929242, upload-time = "2026-01-15T20:15:11.918Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/c5/abd840d4132fd51a12f594934af5eba1d5d27298a6f5b5d6c3be45301caf/ruff-0.14.13-py3-none-win32.whl", hash = "sha256:ef720f529aec113968b45dfdb838ac8934e519711da53a0456038a0efecbd680", size = 12919024, upload-time = "2026-01-15T20:14:43.647Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/55/6384b0b8ce731b6e2ade2b5449bf07c0e4c31e8a2e68ea65b3bafadcecc5/ruff-0.14.13-py3-none-win_amd64.whl", hash = "sha256:6070bd026e409734b9257e03e3ef18c6e1a216f0435c6751d7a8ec69cb59abef", size = 14097887, upload-time = "2026-01-15T20:15:01.48Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/e1/7348090988095e4e39560cfc2f7555b1b2a7357deba19167b600fdf5215d/ruff-0.14.13-py3-none-win_arm64.whl", hash = "sha256:7ab819e14f1ad9fe39f246cfcc435880ef7a9390d81a2b6ac7e01039083dd247", size = 13080224, upload-time = "2026-01-15T20:14:45.853Z" },
+    { url = "https://files.pythonhosted.org/packages/23/18/ee54b7ae1e121be7a28ea6da4b67564ebb0530e183a54415ab7e3bcd2c4e/ruff-0.15.22-py3-none-linux_armv6l.whl", hash = "sha256:44423e73493737f5e7c5b41d475483898ff37afcdae38bc3da5085e29af1c2d8", size = 10781258, upload-time = "2026-07-16T15:13:19.452Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/d2/2520cb14761ddbeaf57642a76942fc36adcbdbe53b4532241995f6fc485c/ruff-0.15.22-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b82c6482946e9eda7ff2e091d25b8bad3f718684e1916d41bd56873cee05b697", size = 10999477, upload-time = "2026-07-16T15:13:23.318Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/10/74e53572aa758dfaa678c2a2646b5c5515d884b7ca56be4d2ce03ca4b560/ruff-0.15.22-py3-none-macosx_11_0_arm64.whl", hash = "sha256:11c1c715af53a09f714e011106bffc419751ec8232fcb5da42173284ea3fec6f", size = 10466716, upload-time = "2026-07-16T15:13:26.162Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/cc/44eaaf0844e028182f2d0a8f2190d0f359159aed0a9e5ab861d892f1ae2a/ruff-0.15.22-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:742a29cf29bddb7c8327895d6a10e0e6c5b38a96dd407af9b5d0857f809c0576", size = 10892644, upload-time = "2026-07-16T15:13:29.229Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/21/8edf559014d2b0f82beea19cfb713993ad802ccda16868769979c6090a84/ruff-0.15.22-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72af58b951b0ae395935ae79763dc349bc0eb706319d28f7a33ad2cfb3cfc178", size = 10576719, upload-time = "2026-07-16T15:13:32.35Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/1e/3a13abd392a3b50b62e5938a831f9ab6e588358cacad5c18545b716d2182/ruff-0.15.22-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:62d425005c1835eb24e2ee4161cb90e8db263415f4a71c8c72c33abaa6c0c224", size = 11376494, upload-time = "2026-07-16T15:13:35.958Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/3e/422d3d95bcf04dd78e1aeac22184d4f9a8fb2c01865d39d44618484a0317/ruff-0.15.22-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e8b9b3f8779a4f08c969defc3c8c35abffaa757e601ed5ae66d6d1db6519969a", size = 12208370, upload-time = "2026-07-16T15:13:39.185Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/91/5d065a0e0a02bf4813f5119ad278462eed081d2b832eb7c021ade0ec9e65/ruff-0.15.22-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1e0dd1b2e4d3d585f897a0d137cbf4eaf6223bef4e8ce34d6bb12556c5f9249e", size = 11581098, upload-time = "2026-07-16T15:13:42.132Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f9/a0d4871d12fae702eb1f41b686caf05f1f8b124dc6db6f784f53d74918fa/ruff-0.15.22-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:365523eb91d9224e1bcb03b022fbf0facb8f9e23792a2c53d9d4b3924bdbdebb", size = 11399422, upload-time = "2026-07-16T15:13:45.2Z" },
+    { url = "https://files.pythonhosted.org/packages/18/80/c843a5176cddbceb0b7e8dd41cf9993490796c1c469348d384f5a5c13c56/ruff-0.15.22-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:fabfd168afdf29fee5be98b831efa9683c94d7c5a3b58b9ce5a2e38444589a74", size = 11381683, upload-time = "2026-07-16T15:13:48.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/00/8485de0ae92239438a36cfc51350db9b9e85c9ebdfaea91b18e422706662/ruff-0.15.22-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:225dbf095a87f1d9f90f5fd7924d2613ee452a75a4308c63a8f50f761787aa7c", size = 10850295, upload-time = "2026-07-16T15:13:51.655Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/91/24977ec2ec72eaf15e4394ace2959fdff2dd1e14f03e005e838023407169/ruff-0.15.22-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:1877d63b9d24ed278744f1523fd11b85540566d54641f97c566d7d9dc5ca5296", size = 10579640, upload-time = "2026-07-16T15:13:54.79Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/47/9b51216951974df1f263ac19da550d34252e0ed7218c25f10c5ef9ed7517/ruff-0.15.22-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a1606c510bd7215680d32efab38965f7cdec3ef69f5170a3f4791404ffdd5262", size = 11105077, upload-time = "2026-07-16T15:13:57.915Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/47/20e9d4a3b8016778acea5fc32bb50d35d207500a17ddb529ffa6996feef8/ruff-0.15.22-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:630479b18625f5ffc373f77603a22a9f8ac0acd7ff0501178b5db28ec71e9c64", size = 11490980, upload-time = "2026-07-16T15:14:01.032Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/76/3f72d8fc38c1cb77b38c56a70da9d0c17700cc1cc50f9649c9d3c8f5ba71/ruff-0.15.22-py3-none-win32.whl", hash = "sha256:e5ba0e4a13fd14abbed2a77b517a3911290c6c6c59ef67784328d1668fab76cf", size = 10789165, upload-time = "2026-07-16T15:14:04.16Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/46/4965251734c2b6fcdca1b1b187d20bcac3af0ee5b083b89c910bb961ce3a/ruff-0.15.22-py3-none-win_amd64.whl", hash = "sha256:9be63ba1eb936acd2d1342fb8337c356353706fce233b2a15a09a97037e6acde", size = 11938297, upload-time = "2026-07-16T15:14:07.316Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c9/e69b1ff4c8b69093ef08b8919ab767af0569666865b39c30a8795d88d3c6/ruff-0.15.22-py3-none-win_arm64.whl", hash = "sha256:e1168075b72158510839f250027659cdd78476f40507dd517892304c41318661", size = 11298172, upload-time = "2026-07-16T15:14:10.51Z" },
 ]
 
 [[package]]
@@ -2118,15 +2117,15 @@ wheels = [
 
 [[package]]
 name = "ya-passport-auth"
-version = "1.7.0"
+version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/b9/29f2efafcae6259639785924739af2e32ad2ddd81a5c1c5ae7b544efbd98/ya_passport_auth-1.7.0.tar.gz", hash = "sha256:ba89a5ce72811b1beedc7e1cb6832b54548506c8ccd3220147bb15050e6d3e8f", size = 101187, upload-time = "2026-07-09T17:23:55.539Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/4a/754473b084524820c5e76bf576235d078b29c15f0f9646191d8d4b177233/ya_passport_auth-1.8.0.tar.gz", hash = "sha256:2271e4cbccea440d917b02e39720327a828dc0a7d70b6420c0216c98a1ebc0cb", size = 105608, upload-time = "2026-07-22T19:59:50.591Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/78/6d757f22f0a7113e0bbdf88e2c2a47f776e6f6d5c8ef816a04abe192661b/ya_passport_auth-1.7.0-py3-none-any.whl", hash = "sha256:c4787963db3ff31d4c72b1d33db92fe6eac88f5e6f7382bb120300cb06fc04db", size = 71465, upload-time = "2026-07-09T17:23:54.339Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/f6/23b7d8559bdf841f171f94008113e88fc286d3965fdb925c6692c7701655/ya_passport_auth-1.8.0-py3-none-any.whl", hash = "sha256:1fb62ad7a01194b74013138d2c73be5342ac3875bbed862041fa1da7c29ed301", size = 74384, upload-time = "2026-07-22T19:59:49.169Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Reverse-sync of upstream PR https://github.com/music-assistant/server/pull/5030 into the standalone `yandex_music` provider.

## Standalone adaptation

Removes the Device/QR popup actions after Music Assistant retired the shared auth-popup helper. New setups use the existing advanced manual music-token entry. Hidden stored x-token/refresh-token values, clear-auth, validation, silent refresh, error mapping, and secret redaction are preserved. The auth maintenance dependency is updated to ya-passport-auth 1.8.0.

Upstream author: @marcelveldt.

## Stack and review order

Includes #225 as its prerequisite. Review/merge order: #225, then this PR. All PRs intentionally remain based on `dev`.

## Verification

- [x] Spec completed (`specs/done/reverse-sync-pr5030.md`)
- [x] CHANGELOG entry finalized
- [x] RED config contract reproduced before implementation
- [x] Auth/config/localization tests: 25 passed
- [x] Full Linux runtime suite: 359 passed, 7 snapshots passed
- [x] Ruff, Python AST, conflict scan, and method-order checks pass
- [x] `uv lock --check` passes with ya-passport-auth 1.8.0
- [x] GitHub reusable CI passes

Maintainer-owned version files were not changed.
