### PR TITLE
reverse-sync: Keep Yandex My Wave dynamically refillable (#5107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parser compatibility baselines now cover the `artist_entity_type` and `life_span` metadata fields introduced by current Music Assistant models.
 - Authentication token maintenance now uses `ya-passport-auth` 1.8.0, including its shared RFC 8628 polling improvements while retaining the existing refresh APIs.
 - Mood and Activity recommendation rows can show the localized tag selected for the current hourly rotation without making discovery-time backend requests.
+- My Wave is now exposed as a dynamic playlist so Music Assistant can refill its queue during playback.
 
 ### Removed
 

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -526,21 +526,12 @@ class YandexMusicProvider(MusicProvider):
 
         # The English name on each folder doubles as the fallback; translation_key localizes
         # it for the connection locale at serialization (the server is the single source).
-        folders: list[BrowseFolder] = []
+        items: list[MediaItemType | ItemMapping | BrowseFolder] = []
         base = path if path.endswith("//") else path.rstrip("/") + "/"
-        # My Wave folder (always enabled — Яндекс «Моя волна»)
-        folders.append(
-            BrowseFolder(
-                item_id=MY_WAVE_PLAYLIST_ID,
-                provider=self.instance_id,
-                path=f"{base}{MY_WAVE_PLAYLIST_ID}",
-                name="My Wave",
-                translation_key=MY_WAVE_PLAYLIST_ID,
-                is_playable=True,
-            )
-        )
+        # My Wave is a dynamic playlist so the queue can request refills.
+        items.append(await self.get_playlist(MY_WAVE_PLAYLIST_ID))
         # Wave modes folder (P4): discover / calm / active / language presets
-        folders.append(
+        items.append(
             BrowseFolder(
                 item_id=MY_WAVE_MODES_FOLDER_ID,
                 provider=self.instance_id,
@@ -552,7 +543,7 @@ class YandexMusicProvider(MusicProvider):
         )
         # User-defined wave presets (P8) — shown only when any configured.
         if self._get_user_wave_presets():
-            folders.append(
+            items.append(
                 BrowseFolder(
                     item_id=MY_WAVE_PRESETS_FOLDER_ID,
                     provider=self.instance_id,
@@ -563,7 +554,7 @@ class YandexMusicProvider(MusicProvider):
                 )
             )
         # For You folder — Picks + Mixes (Яндекс «Для вас»)
-        folders.append(
+        items.append(
             BrowseFolder(
                 item_id=FOR_YOU_FOLDER_ID,
                 provider=self.instance_id,
@@ -584,7 +575,7 @@ class YandexMusicProvider(MusicProvider):
             )
         )
         if has_library:
-            folders.append(
+            items.append(
                 BrowseFolder(
                     item_id=COLLECTION_FOLDER_ID,
                     provider=self.instance_id,
@@ -595,7 +586,7 @@ class YandexMusicProvider(MusicProvider):
                 )
             )
         # Radio folder — rotor stations (Яндекс волны, shown as Radio)
-        folders.append(
+        items.append(
             BrowseFolder(
                 item_id=RADIO_FOLDER_ID,
                 provider=self.instance_id,
@@ -606,7 +597,7 @@ class YandexMusicProvider(MusicProvider):
             )
         )
         # AI Wave Sets — parametric stations from /landing-blocks/mixes-waves
-        folders.append(
+        items.append(
             BrowseFolder(
                 item_id=MY_WAVES_SET_FOLDER_ID,
                 provider=self.instance_id,
@@ -617,7 +608,7 @@ class YandexMusicProvider(MusicProvider):
             )
         )
         # Pinned items — user-pinned artists/albums/playlists/waves
-        folders.append(
+        items.append(
             BrowseFolder(
                 item_id=PINNED_ITEMS_FOLDER_ID,
                 provider=self.instance_id,
@@ -628,7 +619,7 @@ class YandexMusicProvider(MusicProvider):
             )
         )
         # Listening history — recently played tracks/albums
-        folders.append(
+        items.append(
             BrowseFolder(
                 item_id=LISTENING_HISTORY_FOLDER_ID,
                 provider=self.instance_id,
@@ -638,9 +629,9 @@ class YandexMusicProvider(MusicProvider):
                 is_playable=False,
             )
         )
-        if len(folders) == 1:
-            return await self.browse(folders[0].path)
-        return folders
+        if len(items) == 1 and isinstance(items[0], BrowseFolder):
+            return await self.browse(items[0].path)
+        return items
 
     # Search
 
@@ -904,6 +895,7 @@ class YandexMusicProvider(MusicProvider):
                     )
                 },
                 is_editable=False,
+                is_dynamic=True,
             )
 
         if prov_playlist_id == LIKED_TRACKS_PLAYLIST_ID:

--- a/specs/done/reverse-sync-pr5107.md
+++ b/specs/done/reverse-sync-pr5107.md
@@ -1,0 +1,20 @@
+# Reverse-sync: upstream PR #5107
+
+Ported from music-assistant/server#5107 into `yandex_music`.
+
+## Summary
+
+Expose My Wave from provider root browse as the same dynamic virtual playlist
+returned by `get_playlist`. Marking the playlist dynamic lets Music Assistant
+request additional tracks as its queue approaches the end.
+
+## Acceptance criteria
+
+- Root browse returns a `Playlist` for My Wave instead of a playable folder.
+- The virtual My Wave playlist has `is_dynamic=True`.
+- Other root browse folders and their ordering remain unchanged.
+- Existing My Wave playback, pagination, presets, and feedback tests pass.
+
+## Test plan
+
+Run `tests/test_my_wave.py`, then the full repository quality gate.

--- a/tests/test_my_wave.py
+++ b/tests/test_my_wave.py
@@ -7,9 +7,9 @@ from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from music_assistant_models.enums import MediaType
+from music_assistant_models.enums import MediaType, ProviderFeature
 from music_assistant_models.errors import InvalidDataError
-from music_assistant_models.media_items import ProviderMapping
+from music_assistant_models.media_items import Playlist, ProviderMapping
 from music_assistant_models.media_items import Track as MATrack
 
 from music_assistant.providers.yandex_music import (
@@ -17,6 +17,7 @@ from music_assistant.providers.yandex_music import (
     _save_wave_preset_action,
 )
 from music_assistant.providers.yandex_music.constants import (
+    MY_WAVE_PLAYLIST_ID,
     RADIO_TRACK_ID_SEP,
     ROTOR_STATION_MY_WAVE,
 )
@@ -72,6 +73,38 @@ def test_wave_state_is_per_instance_isolated() -> None:
     assert b.seen_track_ids == set()
     assert b.prefetched == []
     assert b.settings == {}
+
+
+async def test_root_browse_exposes_my_wave_as_dynamic_playlist() -> None:
+    """Root browse returns My Wave as a dynamic playlist."""
+    provider = Mock(spec=YandexMusicProvider)
+    provider.instance_id = "yandex_music_instance"
+    provider.supported_features = {ProviderFeature.BROWSE}
+    provider._get_user_wave_presets.return_value = []
+    dynamic = Playlist(
+        item_id=MY_WAVE_PLAYLIST_ID,
+        provider=provider.instance_id,
+        name="My Wave",
+        provider_mappings=set(),
+        is_dynamic=True,
+    )
+    provider.get_playlist = AsyncMock(return_value=dynamic)
+
+    items = await YandexMusicProvider.browse(provider, "yandex_music_instance://")
+
+    assert isinstance(items[0], Playlist)
+    assert items[0].is_dynamic is True
+
+
+async def test_virtual_my_wave_playlist_is_dynamic() -> None:
+    """The locally constructed My Wave playlist requests dynamic refill."""
+    provider = Mock(spec=YandexMusicProvider)
+    provider.instance_id = "yandex_music_instance"
+    provider.domain = "yandex_music"
+
+    playlist = await YandexMusicProvider.get_playlist(provider, MY_WAVE_PLAYLIST_ID)
+
+    assert playlist.is_dynamic is True
 
 
 # -- _fetch_rotor_session_batch (session-API helper) --------------------------


### PR DESCRIPTION
Reverse-sync of upstream PR https://github.com/music-assistant/server/pull/5107 into the standalone `yandex_music` provider.

## Standalone adaptation

Returns My Wave from provider root browse as the same virtual `Playlist` used for playback and marks it `is_dynamic=True`, allowing Music Assistant to refill the queue after the initial batch.

Upstream author: @alectogeek.

## Stack and review order

Includes #225 and #230. It can be reviewed after #230 and is independent of #226/#228. All PRs intentionally remain based on `dev`.

## Verification

- [x] Spec completed (`specs/done/reverse-sync-pr5107.md`)
- [x] CHANGELOG entry finalized
- [x] RED behavior reproduced before implementation
- [x] My Wave tests: 36 passed
- [x] Full Linux runtime suite: 361 passed, 7 snapshots passed
- [x] Ruff, Python AST, conflict scan, and method-order checks pass
- [x] GitHub reusable CI passes

Maintainer-owned version files were not changed.
