### PR TITLE
reverse-sync: Turn guest access into a normal on/off setting (#5298)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -663,3 +663,4 @@ No changes.
 
 - feat: add Yandex Music provider (music-assistant/server#3002)
 - Reverse-synced upstream PR #4637 (WIP)
+- Reverse-synced upstream PR #5298 (WIP)

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -507,7 +507,7 @@ class YandexMusicProvider(MusicProvider):
             ),
         )
 
-    async def handle_config_action(self, action: str) -> tuple[ConfigEntry, ...]:
+    async def handle_config_action(self, action: str) -> tuple[ConfigEntry, ...] | None:
         """
         Handle a wave-preset save/delete button press and re-render the entries.
 

--- a/specs/inprogress/reverse-sync-pr5298.md
+++ b/specs/inprogress/reverse-sync-pr5298.md
@@ -1,0 +1,9 @@
+# Reverse-sync: upstream PR #5298
+
+WIP=1
+
+Ported from music-assistant/server#5298 into `yandex_music`.
+
+## Summary
+
+_TODO: describe the change._


### PR DESCRIPTION
Reverse-sync of upstream PR https://github.com/music-assistant/server/pull/5298 into the `yandex_music` provider.

Original author: @marcelveldt (credited via `Co-authored-by`).

**Maintainer-owned files were NOT touched** — review `VERSION` and `translations/en.json` manually if the upstream change implies a bump.

- [ ] Spec filled in (`specs/inprogress/`)
- [ ] CHANGELOG entry finalized
- [ ] Tests pass locally