### PR TITLE
reverse-sync: Avoid duplicate provider requests for the same uncached data (#5370)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -663,3 +663,4 @@ No changes.
 
 - feat: add Yandex Music provider (music-assistant/server#3002)
 - Reverse-synced upstream PR #4637 (WIP)
+- Reverse-synced upstream PR #5370 (WIP)

--- a/specs/inprogress/reverse-sync-pr5370.md
+++ b/specs/inprogress/reverse-sync-pr5370.md
@@ -1,0 +1,9 @@
+# Reverse-sync: upstream PR #5370
+
+WIP=1
+
+Ported from music-assistant/server#5370 into `yandex_music`.
+
+## Summary
+
+_TODO: describe the change._


### PR DESCRIPTION
Reverse-sync of upstream PR https://github.com/music-assistant/server/pull/5370 into the `yandex_music` provider.

> ⚠ Patch applied with **conflicts** — `.rej`/markers left in the tree. Resolve them before marking ready.


Original author: @marcelveldt (credited via `Co-authored-by`).

**Maintainer-owned files were NOT touched** — review `VERSION` and `translations/en.json` manually if the upstream change implies a bump.

- [ ] Spec filled in (`specs/inprogress/`)
- [ ] CHANGELOG entry finalized
- [ ] Tests pass locally