### PR TITLE
reverse-sync: Show what a settings action did instead of redrawing the form (#5402)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -663,3 +663,4 @@ No changes.
 
 - feat: add Yandex Music provider (music-assistant/server#3002)
 - Reverse-synced upstream PR #4637 (WIP)
+- Reverse-synced upstream PR #5402 (WIP)

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -12,7 +12,11 @@ from collections.abc import AsyncGenerator, Sequence
 from io import BytesIO
 from typing import TYPE_CHECKING, Any
 
-from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
+from music_assistant_models.config_entries import (
+    ConfigActionResult,
+    ConfigEntry,
+    ConfigValueOption,
+)
 from music_assistant_models.enums import (
     ConfigEntryType,
     ImageType,
@@ -507,7 +511,13 @@ class YandexMusicProvider(MusicProvider):
             ),
         )
 
+<<<<<<< ours
     async def handle_config_action(self, action: str) -> tuple[ConfigEntry, ...]:
+=======
+    async def handle_config_action(
+        self, action: str
+    ) -> tuple[ConfigEntry, ...] | ConfigActionResult | None:
+>>>>>>> theirs
         """
         Handle a wave-preset save/delete button press and re-render the entries.
 

--- a/specs/inprogress/reverse-sync-pr5402.md
+++ b/specs/inprogress/reverse-sync-pr5402.md
@@ -1,0 +1,9 @@
+# Reverse-sync: upstream PR #5402
+
+WIP=1
+
+Ported from music-assistant/server#5402 into `yandex_music`.
+
+## Summary
+
+_TODO: describe the change._


### PR DESCRIPTION
Reverse-sync of upstream PR https://github.com/music-assistant/server/pull/5402 into the `yandex_music` provider.

> ⚠ Patch applied with **conflicts** — `.rej`/markers left in the tree. Resolve them before marking ready.


Original author: @marcelveldt (credited via `Co-authored-by`).

**Maintainer-owned files were NOT touched** — review `VERSION` and `translations/en.json` manually if the upstream change implies a bump.

- [ ] Spec filled in (`specs/inprogress/`)
- [ ] CHANGELOG entry finalized
- [ ] Tests pass locally