### PR TITLE
reverse-sync: Share My Wave and My Mix track requests between listeners (#5464)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -663,3 +663,4 @@ No changes.
 
 - feat: add Yandex Music provider (music-assistant/server#3002)
 - Reverse-synced upstream PR #4637 (WIP)
+- Reverse-synced upstream PR #5464 (WIP)

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -3310,6 +3310,10 @@ class YandexMusicProvider(MusicProvider):
             raise MediaNotFoundError(f"Playlist {prov_playlist_id} not found")
         return parse_playlist(self, playlist)
 
+<<<<<<< ours
+=======
+    @use_cache(3600 * 3, allow_expired_cache=True)
+>>>>>>> theirs
     async def _get_my_wave_playlist_tracks(self, page: int) -> list[Track]:
         """
         Get My Wave tracks for virtual playlist (uncached; uses cursor for page > 0).

--- a/specs/inprogress/reverse-sync-pr5464.md
+++ b/specs/inprogress/reverse-sync-pr5464.md
@@ -1,0 +1,9 @@
+# Reverse-sync: upstream PR #5464
+
+WIP=1
+
+Ported from music-assistant/server#5464 into `yandex_music`.
+
+## Summary
+
+_TODO: describe the change._

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -213,7 +213,96 @@ async def test_get_playlist_tracks_raises_only_when_every_batch_is_empty() -> No
 
     fn: Any = YandexMusicProvider.get_playlist_tracks.__wrapped__  # type: ignore[attr-defined]
     with pytest.raises(ResourceTemporarilyUnavailable):
+<<<<<<< ours
         await fn(provider, "12345:67")
+=======
+        await cached.__wrapped__(provider, "12345:67", 0)
+
+
+# -- request coalescing is scoped to the branch that must run per call --------
+
+
+class _StubConfig:
+    """Minimal provider config for the @use_cache decorator."""
+
+    instance_id = "yandex_music_test"
+
+    def get_value(self, key: str, default: Any = None) -> Any:
+        """Return the default for every config key."""
+        return default
+
+
+@pytest.fixture
+async def cached_provider(
+    mass_minimal: MusicAssistant,
+) -> tuple[YandexMusicProvider, mock.AsyncMock]:
+    """Return a provider backed by a real (empty) cache controller."""
+    await mass_minimal.cache._setup_database()
+    provider, mock_client = _make_provider()
+    provider.mass = mass_minimal
+    provider.config = _StubConfig()  # type: ignore[assignment]
+    provider.manifest = mock.MagicMock(domain="yandex_music")
+    provider._wave_states = {}
+    return provider, mock_client
+
+
+async def _wait_for_gated_fetch(started: Callable[[], bool]) -> None:
+    """Wait until the gated fetch runs, then let the other callers catch up with it."""
+    for _ in range(200):
+        if started():
+            break
+        await asyncio.sleep(0.01)
+    else:
+        pytest.fail("gated fetch never started")
+    # a caller arriving after the gate is released would start a second fetch,
+    # which the await-count assertions below catch
+    await asyncio.sleep(0.05)
+
+
+async def test_regular_playlist_fetch_is_shared_between_callers(
+    cached_provider: tuple[YandexMusicProvider, mock.AsyncMock],
+) -> None:
+    """Concurrent callers for the same regular playlist share one provider fetch."""
+    provider, mock_client = cached_provider
+    gate = asyncio.Event()
+
+    async def _get_playlist(*_args: Any, **_kwargs: Any) -> Any:
+        await gate.wait()
+        return type("PL", (), {"tracks": [], "track_count": 0})()
+
+    mock_client.get_playlist = mock.AsyncMock(side_effect=_get_playlist)
+
+    tasks = [asyncio.create_task(provider.get_playlist_tracks("12345:67")) for _ in range(3)]
+    await _wait_for_gated_fetch(lambda: mock_client.get_playlist.await_count > 0)
+    gate.set()
+
+    assert await asyncio.gather(*tasks) == [[], [], []]
+    assert mock_client.get_playlist.await_count == 1
+
+
+async def test_my_wave_fetch_is_shared_between_callers(
+    cached_provider: tuple[YandexMusicProvider, mock.AsyncMock],
+) -> None:
+    """Concurrent My Wave callers share one fetch, so the rotor advances once."""
+    provider, _ = cached_provider
+    gate = asyncio.Event()
+
+    async def _fetch_batch(*_args: Any, **_kwargs: Any) -> tuple[list[Any], None]:
+        await gate.wait()
+        return [], None
+
+    fetch_batch = mock.AsyncMock(side_effect=_fetch_batch)
+    provider._fetch_rotor_session_batch = fetch_batch  # type: ignore[method-assign]
+
+    tasks = [
+        asyncio.create_task(provider.get_playlist_tracks(MY_WAVE_PLAYLIST_ID)) for _ in range(3)
+    ]
+    await _wait_for_gated_fetch(lambda: fetch_batch.await_count > 0)
+    gate.set()
+
+    assert await asyncio.gather(*tasks) == [[], [], []]
+    assert fetch_batch.await_count == 1
+>>>>>>> theirs
 
 
 # -- M11: unload() must clear every per-session cache -------------------------


### PR DESCRIPTION
Reverse-sync of upstream PR https://github.com/music-assistant/server/pull/5464 into the `yandex_music` provider.

> ⚠ Patch applied with **conflicts** — `.rej`/markers left in the tree. Resolve them before marking ready.


Original author: @marcelveldt (credited via `Co-authored-by`).

**Maintainer-owned files were NOT touched** — review `VERSION` and `translations/en.json` manually if the upstream change implies a bump.

- [ ] Spec filled in (`specs/inprogress/`)
- [ ] CHANGELOG entry finalized
- [ ] Tests pass locally